### PR TITLE
Multiple vocabularies

### DIFF
--- a/iati/core/resources/data/valid_iati_vocab_multiple_different_invalid_code.xml
+++ b/iati/core/resources/data/valid_iati_vocab_multiple_different_invalid_code.xml
@@ -16,7 +16,7 @@
     <activity-status code="2"/>
     <activity-date type="1" iso-date="2023-11-27"/>
     <!-- Multiple sector elements, each specifying a different code from different vocabs. -->
-    <sector code="112" percentage="30" /><!-- No vocabulary set, so default vocab assumed. @code not on default vocab. -->
-    <sector vocabulary="2" code="11110" percentage="70" /><!-- Non-default vocabulary set. @code value not on this vocab. -->
+    <sector code="112" /><!-- No vocabulary set, so default vocab assumed. @code not on default vocab. -->
+    <sector vocabulary="2" code="11110" /><!-- Non-default vocabulary set. @code value not on this vocab. -->
   </iati-activity>
 </iati-activities>

--- a/iati/core/resources/data/valid_iati_vocab_multiple_different_invalid_code.xml
+++ b/iati/core/resources/data/valid_iati_vocab_multiple_different_invalid_code.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+    <!-- Multiple sector elements, each specifying a different code from different vocabs. -->
+    <sector code="112" percentage="30" /><!-- No vocabulary set, so default vocab assumed. @code not on default vocab. -->
+    <sector vocabulary="2" code="11110" percentage="70" /><!-- Non-default vocabulary set. @code value not on this vocab. -->
+  </iati-activity>
+</iati-activities>

--- a/iati/core/resources/data/valid_iati_vocab_multiple_different_valid.xml
+++ b/iati/core/resources/data/valid_iati_vocab_multiple_different_valid.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+    <!-- Multiple sector elements, each specifying a different code from different vocabs. -->
+    <sector code="11110" percentage="30" /><!-- No vocabulary set, so default vocab assumed. @code value taken from default vocab. -->
+    <sector vocabulary="2" code="112" percentage="70" /><!-- Non-default vocabulary set. @code value taken from this vocab. -->
+  </iati-activity>
+</iati-activities>

--- a/iati/core/resources/data/valid_iati_vocab_multiple_different_valid.xml
+++ b/iati/core/resources/data/valid_iati_vocab_multiple_different_valid.xml
@@ -16,7 +16,7 @@
     <activity-status code="2"/>
     <activity-date type="1" iso-date="2023-11-27"/>
     <!-- Multiple sector elements, each specifying a different code from different vocabs. -->
-    <sector code="11110" percentage="30" /><!-- No vocabulary set, so default vocab assumed. @code value taken from default vocab. -->
-    <sector vocabulary="2" code="112" percentage="70" /><!-- Non-default vocabulary set. @code value taken from this vocab. -->
+    <sector code="11110" /><!-- No vocabulary set, so default vocab assumed. @code value taken from default vocab. -->
+    <sector vocabulary="2" code="112" /><!-- Non-default vocabulary set. @code value taken from this vocab. -->
   </iati-activity>
 </iati-activities>

--- a/iati/core/resources/data/valid_iati_vocab_multiple_same_invalid_code.xml
+++ b/iati/core/resources/data/valid_iati_vocab_multiple_same_invalid_code.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+    <!-- Multiple sector elements, each specifying a different code from the same vocab. -->
+    <sector code="112" percentage="30" /><!-- No vocabulary set, so default vocab assumed. @code value is not on the default vocab. -->
+    <sector vocabulary="1" code="111" percentage="70" /><!-- Default vocabulary mentioned explicitly. @code value not on this vocab. -->
+  </iati-activity>
+</iati-activities>

--- a/iati/core/resources/data/valid_iati_vocab_multiple_same_valid.xml
+++ b/iati/core/resources/data/valid_iati_vocab_multiple_same_valid.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+    <!-- Multiple sector elements, each specifying a different code from the same vocab. -->
+    <sector code="11110" percentage="30" /><!-- No vocabulary set, so default vocab assumed. @code value taken from default vocab. -->
+    <sector vocabulary="1" code="11120" percentage="70" /><!-- Default vocabulary mentioned explicitly. @code value taken from this vocab. -->
+  </iati-activity>
+</iati-activities>

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -39,6 +39,14 @@ XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = iati.core.resources.loa
 """A string contains valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code not in list."""
 XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_non_default'))
 """A string contains valid IATI XML containing an element that uses vocabularies. Explicitly defines non-default vocab and uses code from that list."""
+XML_STR_VALID_IATI_VOCAB_MULTIPLE_SAME_VALID = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_same_valid'))
+"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is the same. @code values are valid. Percentages add up to 100."""
+XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_VALID = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_different_valid'))
+"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. @code values are valid.Percentages add up to 100."""
+XML_STR_VALID_IATI_VOCAB_MULTIPLE_SAME_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_same_invalid_code'))
+"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is the same. @code values are not valid. Percentages add up to 100."""
+XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_different_invalid_code'))
+"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. @code values are not valid. Percentages add up to 100."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_user_defined'))
 """A string contains valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_user_defined_with_uri_readable'))

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -42,11 +42,11 @@ XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = iati.core.resources.load_as_string(iati.c
 XML_STR_VALID_IATI_VOCAB_MULTIPLE_SAME_VALID = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_same_valid'))
 """A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is the same. @code values are valid. Percentages add up to 100."""
 XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_VALID = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_different_valid'))
-"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. @code values are valid.Percentages add up to 100."""
+"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. @code values are valid."""
 XML_STR_VALID_IATI_VOCAB_MULTIPLE_SAME_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_same_invalid_code'))
 """A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is the same. @code values are not valid. Percentages add up to 100."""
 XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_multiple_different_invalid_code'))
-"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. @code values are not valid. Percentages add up to 100."""
+"""A string contains valid IATI XML containing an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. @code values are not valid."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_user_defined'))
 """A string contains valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = iati.core.resources.load_as_string(iati.core.resources.path_data('valid_iati_vocab_user_defined_with_uri_readable'))

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -136,6 +136,62 @@ class TestValidate(object):
 
         assert iati.validate.is_valid(data, schema)
 
+    def test_validation_codelist_vocab_multiple_same_valid(self):
+        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is the same. The codes are valid against the vocabularies. Percentages add up to 100."""
+        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_MULTIPLE_SAME_VALID)
+        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        codelist_1 = iati.core.default.codelists()['SectorVocabulary']
+        codelist_2 = iati.core.default.codelists()['Sector']
+        codelist_3 = iati.core.default.codelists()['SectorCategory']
+
+        schema.codelists.add(codelist_1)
+        schema.codelists.add(codelist_2)
+        schema.codelists.add(codelist_3)
+
+        assert iati.validate.is_valid(data, schema)
+
+    def test_validation_codelist_vocab_multiple_different_valid(self):
+        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. The codes are valid against the vocabularies. Percentages add up to 100."""
+        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_VALID)
+        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        codelist_1 = iati.core.default.codelists()['SectorVocabulary']
+        codelist_2 = iati.core.default.codelists()['Sector']
+        codelist_3 = iati.core.default.codelists()['SectorCategory']
+
+        schema.codelists.add(codelist_1)
+        schema.codelists.add(codelist_2)
+        schema.codelists.add(codelist_3)
+
+        assert iati.validate.is_valid(data, schema)
+
+    def test_validation_codelist_vocab_multiple_same_invalid_code(self):
+        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is the same. The codes are valid against the vocabularies. Percentages add up to 100."""
+        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_MULTIPLE_SAME_INVALID_CODE)
+        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        codelist_1 = iati.core.default.codelists()['SectorVocabulary']
+        codelist_2 = iati.core.default.codelists()['Sector']
+        codelist_3 = iati.core.default.codelists()['SectorCategory']
+
+        schema.codelists.add(codelist_1)
+        schema.codelists.add(codelist_2)
+        schema.codelists.add(codelist_3)
+
+        assert not iati.validate.is_valid(data, schema)
+
+    def test_validation_codelist_vocab_multiple_different_invalid_code(self):
+        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. The codes are valid against the vocabularies. Percentages add up to 100."""
+        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_INVALID_CODE)
+        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        codelist_1 = iati.core.default.codelists()['SectorVocabulary']
+        codelist_2 = iati.core.default.codelists()['Sector']
+        codelist_3 = iati.core.default.codelists()['SectorCategory']
+
+        schema.codelists.add(codelist_1)
+        schema.codelists.add(codelist_2)
+        schema.codelists.add(codelist_3)
+
+        assert not iati.validate.is_valid(data, schema)
+
     def test_validation_codelist_vocab_user_defined(self):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
         data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED)

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -151,7 +151,7 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_multiple_different_valid(self):
-        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. The codes are valid against the vocabularies. Percentages add up to 100."""
+        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. The codes are valid against the vocabularies."""
         data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_VALID)
         schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
@@ -179,7 +179,7 @@ class TestValidate(object):
         assert not iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_multiple_different_invalid_code(self):
-        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. The codes are valid against the vocabularies. Percentages add up to 100."""
+        """Perform data validation against valid IATI XML with an activity that uses multiple instances of the same element that uses vocabularies. The vocabulary used by each of these elements is different. The codes are valid against the vocabularies."""
         data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_MULTIPLE_DIFFERENT_INVALID_CODE)
         schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']


### PR DESCRIPTION
Add support for multiple vocabularies being defined for a single element.

For example, validation that:

```xml
<sector code="11110" />
<sector vocabulary="2" code="112" />
```

is valid, while

```xml
<sector code="112" />
<sector vocabulary="2" code="11110" />
```

is invalid since the default vocabulary, `1`, contains 5-digit codes, while vocab `2` contains 3-digit codes.