### PR TITLE
Add requires.io filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The iati.core Python module.
 
-[![Build Status](https://travis-ci.org/IATI/iati.core.svg?branch=master)](https://travis-ci.com/IATI/iati.core)
+[![Build Status](https://travis-ci.org/IATI/iati.core.svg?branch=master)](https://travis-ci.com/IATI/iati.core) [![Requirements Status](https://requires.io/github/IATI/iati.core/requirements.svg?branch=master)](https://requires.io/github/IATI/iati.core/requirements/?branch=master)
 
 Varying between: [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges) and [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges) (see docstrings)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,21 +8,21 @@
 #
 
 # linters
-flake8==3.2.1
-pydocstyle==1.1.1
-pylint==1.6.5
+flake8==3.2.1 # rq.filter: <4.0
+pydocstyle==1.1.1 # rq.filter: <2.0
+pylint==1.6.5 # rq.filter: <2.0
 
 # code complexity
-radon==1.4.2
+radon==1.4.2 # rq.filter: <2.0
 
 # testing tools
-pytest==3.0.5
-pytest-cov==2.4.0
+pytest==3.0.5 # rq.filter: <4.0
+pytest-cov==2.4.0 # rq.filter: <3.0
 
 #
 # distribution requirements
 #
 
 # documentation
-Sphinx==1.5.2
-sphinx_rtd_theme==0.1.9
+Sphinx==1.5.2 # rq.filter: <2.0
+sphinx_rtd_theme==0.1.9 # rq.filter: <1.0


### PR DESCRIPTION
Add filters to `requirements-dev.txt` to prevent requires.io from making integer (non-backwards-compatible) suggestions.

https://requires.io/features/