### PR TITLE
Update lxml to 3.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='http://iatistandard.org/',
     packages = find_packages(exclude='iati/core/tests'),
     install_requires = [
-        'lxml==3.6.0'
+        'lxml==3.8.0'
         ],
     classifiers = [
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
This adds various new capabilities. The most important of these is adding a `path` attribute to items in error logs, providing an XPath to indicate where a problem occurred in the source document.