### PR TITLE
Undertake integer requirements updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint: $(IATI_FOLDER)
 	echo $(LINE_SEP)
 	-flake8 $(IATI_FOLDER)
 	echo $(LINE_SEP)
-	pydocstyle $(IATI_FOLDER)
+	-pydocstyle $(IATI_FOLDER)
 
 
 test: $(IATI_FOLDER)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,11 +9,11 @@
 
 # linters
 flake8==3.2.1 # rq.filter: <4.0
-pydocstyle==1.1.1 # rq.filter: <2.0
+pydocstyle==2.0.0 # rq.filter: <3.0
 pylint==1.6.5 # rq.filter: <2.0
 
 # code complexity
-radon==1.4.2 # rq.filter: <2.0
+radon==2.0.2 # rq.filter: <3.0
 
 # testing tools
 pytest==3.0.5 # rq.filter: <4.0


### PR DESCRIPTION
A couple of reqquirements are being updated to the next integer. The primary reason for integer in both cases is dropping of Python 2.6 support. As such, this update doesn't really impact iati.core