### PR TITLE
Remove try/except block in StringIO import

### DIFF
--- a/iati/core/utilities.py
+++ b/iati/core/utilities.py
@@ -1,10 +1,7 @@
 """A module containing utility functions."""
 import logging
 import os
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 from lxml import etree
 import iati.core.constants
 


### PR DESCRIPTION
The statement `from io import StringIO` is valid
in both python2 and python3.