### PR TITLE
[#31] Reduce the verbosity of function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following example loads the included IATI v2.02 schema at:  `iati.core/iati/
 
 ```
 import iati.core.schemas
-schema = iati.core.schemas.Schema(name='iati-activities-schema')
+schema = iati.core.Schema(name='iati-activities-schema')
 ```
 
 ### Loading codelists
@@ -103,7 +103,7 @@ with open('path/to/iati-activites.xml', 'r') as xml_file_object:
 import requests
 dataset_as_string = requests.get('http://XML_FILE_URL_HERE').text
 
-dataset = iati.core.data.Dataset(dataset_as_string)
+dataset = iati.core.Dataset(dataset_as_string)
 ```
 
 #### Accessing data

--- a/iati/core/__init__.py
+++ b/iati/core/__init__.py
@@ -1,1 +1,5 @@
 """A package containing core IATI functionality."""
+from .codelists import Code, Codelist
+from .data import Dataset
+from .rulesets import Rule, Ruleset
+from .schemas import Schema

--- a/iati/core/codelists.py
+++ b/iati/core/codelists.py
@@ -9,7 +9,7 @@ class Codelist(object):
     """Representation of a Codelist as defined within the IATI SSOT.
 
     Attributes:
-        codes (:obj:`set` of :obj:`iati.core.codelists.Code`): The codes demonstrating the range of values that the Codelist may represent.
+        codes (:obj:`set` of :obj:`iati.core.Code`): The codes demonstrating the range of values that the Codelist may represent.
         name (str): The name of the Codelist.
 
     Private Attributes:
@@ -80,7 +80,7 @@ class Codelist(object):
                     value = ''
                 if name is None:
                     name = ''
-                self.codes.add(iati.core.codelists.Code(value, name))
+                self.codes.add(iati.core.Code(value, name))
 
         self.codes = set()
         self.name = name

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -31,7 +31,7 @@ def codelist(name, version=None):
         ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
-        iati.core.codelists.Codelist: A Codelist with the specified name.
+        iati.core.Codelist: A Codelist with the specified name.
 
     Warning:
         A name may not be sufficient to act as a UID.
@@ -65,7 +65,7 @@ def codelists(version=None, bypass_cache=False):
         ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
-        dict: A dictionary containing all the Codelists at the specified version of the Standard. All Non-Embedded Codelists are included. Keys are Codelist names. Values are iati.core.codelists.Codelist() instances.
+        dict: A dictionary containing all the Codelists at the specified version of the Standard. All Non-Embedded Codelists are included. Keys are Codelist names. Values are iati.core.Codelist() instances.
 
     Warning:
         Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
@@ -86,7 +86,7 @@ def codelists(version=None, bypass_cache=False):
         name = filename[:-len(iati.core.resources.FILE_CODELIST_EXTENSION)]  # Get the name of the codelist, without the '.xml' file extension
         if (name not in _CODELISTS.keys()) or bypass_cache:
             xml_str = iati.core.resources.load_as_string(path)
-            codelist_found = iati.core.codelists.Codelist(name, xml=xml_str)
+            codelist_found = iati.core.Codelist(name, xml=xml_str)
             _CODELISTS[name] = codelist_found
 
     return _CODELISTS
@@ -106,7 +106,7 @@ def schemas(bypass_cache=False):
         bypass_cache (bool): Whether the cache should be bypassed, instead reloading data from disk even if it's already been loaded.
 
     Returns:
-        dict: A dictionary containing all the Schemas for versions of the Standard. The version of the Standard is the key. An iati.core.schemas.Schema() is each value.
+        dict: A dictionary containing all the Schemas for versions of the Standard. The version of the Standard is the key. An iati.core.Schema() is each value.
 
     Warning:
         The `bypass_cache` parameter could potentially be implemented in a cleaner manner. It also shouldn't really exist until a clear use-case is defined - changes elsewhere in the library may make it redundant.
@@ -127,7 +127,7 @@ def schemas(bypass_cache=False):
     for path in paths:
         name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
         if (name not in _SCHEMAS.keys()) or bypass_cache:
-            schema = iati.core.schemas.Schema(name)
+            schema = iati.core.Schema(name)
             _SCHEMAS[name] = schema
 
     return _SCHEMAS

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -18,7 +18,7 @@ class Schema(object):
         The private attribute allowing access to the base Schema Tree is likely to change in determining a good way of accessing the contained schema content.
 
     Todo:
-        Determine a good API for accessing the XMLSchema that the iati.core.schemas.Schema represents.
+        Determine a good API for accessing the XMLSchema that the iati.core.Schema represents.
 
         Determine how to distinguish and handle the different types of Schema - activity, organisation, codelist, other.
     """

--- a/iati/core/tests/test_codelists.py
+++ b/iati/core/tests/test_codelists.py
@@ -29,7 +29,7 @@ class TestCodelists(object):
     def test_codelist_default_attributes(self):
         """Check a Codelist's default attributes are correct"""
         try:
-            _ = iati.core.codelists.Codelist()  # pylint: disable=E1120
+            _ = iati.core.Codelist()  # pylint: disable=E1120
         except TypeError:
             assert True
         else:  # pragma: no cover
@@ -38,7 +38,7 @@ class TestCodelists(object):
 
     def test_codelist_name_instance(self, name_to_set):
         """Check a Codelist's attributes are correct when defined with only a name"""
-        codelist = iati.core.codelists.Codelist(name_to_set)
+        codelist = iati.core.Codelist(name_to_set)
 
         assert set() == codelist.codes
         assert codelist.name == name_to_set
@@ -46,15 +46,15 @@ class TestCodelists(object):
     def test_codelist_name_and_path_instance(self, name_to_set):
         """Check a Codelist's attributes are correct when defined with a name and path"""
         path_to_set = "test Codelist path"
-        codelist = iati.core.codelists.Codelist(name_to_set, path_to_set)
+        codelist = iati.core.Codelist(name_to_set, path_to_set)
 
         assert set() == codelist.codes
         assert codelist.name == name_to_set
 
     def test_codelist_add_code(self, name_to_set):
         """Check a Code can be added to a Codelist"""
-        codelist = iati.core.codelists.Codelist(name_to_set)
-        code = iati.core.codelists.Code()
+        codelist = iati.core.Codelist(name_to_set)
+        code = iati.core.Code()
         codelist.codes.add(code)
 
         num_codes = len(codelist.codes)
@@ -64,7 +64,7 @@ class TestCodelists(object):
     @pytest.mark.xfail
     def test_codelist_add_code_decline_non_code(self, name_to_set):
         """Check something that is not a Code cannot be added to a Codelist"""
-        codelist = iati.core.codelists.Codelist(name_to_set)
+        codelist = iati.core.Codelist(name_to_set)
         not_a_code = True
         codelist.codes.add(not_a_code)
 
@@ -76,7 +76,7 @@ class TestCodelists(object):
         """Check that a Codelist can be generated from an XML codelist definition."""
         path = iati.core.resources.get_codelist_path('FlowType')
         xml_str = iati.core.resources.load_as_string(path)
-        codelist = iati.core.codelists.Codelist(name_to_set, xml=xml_str)
+        codelist = iati.core.Codelist(name_to_set, xml=xml_str)
 
         code_names = ['ODA', 'OOF', 'Private grants', 'Private Market', 'Non flow', 'Other flows']
         code_values = ['10', '20', '30', '35', '40', '50']
@@ -90,8 +90,8 @@ class TestCodelists(object):
     def test_codelist_type_xsd(self, name_to_set):
         """Check that a Codelist can turn itself into a type to use for validation."""
         code_value_to_set = "test Code value"
-        codelist = iati.core.codelists.Codelist(name_to_set)
-        code = iati.core.codelists.Code(code_value_to_set)
+        codelist = iati.core.Codelist(name_to_set)
+        code = iati.core.Code(code_value_to_set)
         codelist.codes.add(code)
 
         type_tree = codelist.xsd_tree()
@@ -116,7 +116,7 @@ class TestCodes(object):
 
     def test_code_default_attributes(self):
         """Check a Code's default attributes are correct"""
-        code = iati.core.codelists.Code()
+        code = iati.core.Code()
 
         assert code.name is None
         assert code.value is None
@@ -124,7 +124,7 @@ class TestCodes(object):
     def test_code_value_instance(self):
         """Check a Code's attributes are correct when being defined with only a value"""
         value_to_set = "test Code value"
-        code = iati.core.codelists.Code(value_to_set)
+        code = iati.core.Code(value_to_set)
 
         assert code.name is None
         assert code.value == value_to_set
@@ -133,7 +133,7 @@ class TestCodes(object):
         """Check a Code's attributes are correct when being defined with a value and name"""
         value_to_set = "test Code value"
         name_to_set = "test Code name"
-        code = iati.core.codelists.Code(value_to_set, name_to_set)
+        code = iati.core.Code(value_to_set, name_to_set)
 
         assert code.name == name_to_set
         assert code.value == value_to_set
@@ -145,7 +145,7 @@ class TestCodes(object):
             Test enumerating a Code with no value.
         """
         value_to_set = "test Code value"
-        code = iati.core.codelists.Code(value_to_set)
+        code = iati.core.Code(value_to_set)
 
         enum_el = code.xsd_tree()
 

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -15,12 +15,12 @@ class TestDatasets(object):
     @pytest.fixture
     def dataset_initialised(self):
         """Return an initialised dataset to work from in other tests."""
-        return iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
+        return iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
 
     def test_dataset_no_params(self):
         """Test Dataset creation with no parameters."""
         try:
-            _ = iati.core.data.Dataset()  # pylint: disable=E1120
+            _ = iati.core.Dataset()  # pylint: disable=E1120
         except TypeError:
             assert True
         else:  # pragma: no cover
@@ -29,14 +29,14 @@ class TestDatasets(object):
 
     def test_dataset_valid_xml_string(self):
         """Test Dataset creation with a valid XML string that is not IATI data."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
 
         assert data.xml_str == iati.core.tests.utilities.XML_STR_VALID_NOT_IATI
         assert etree.tostring(data.xml_tree) == etree.tostring(iati.core.tests.utilities.XML_TREE_VALID)
 
     def test_dataset_xml_string_leading_whitespace(self):
         """Test Dataset creation with a valid XML string that is not IATI data."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE)
         tree = etree.fromstring(iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE.strip())
 
         assert data.xml_str == iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE.strip()
@@ -49,7 +49,7 @@ class TestDatasets(object):
     def test_dataset_invalid_xml_string(self):
         """Test Dataset creation with a string that is not valid XML."""
         try:
-            _ = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
+            _ = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
         except ValueError:
             assert True
         else:  # pragma: no cover
@@ -60,7 +60,7 @@ class TestDatasets(object):
     def test_dataset_number_not_xml(self, not_xml):
         """Test Dataset creation when it's passed a number rather than a string or etree."""
         try:
-            _ = iati.core.data.Dataset(not_xml)
+            _ = iati.core.Dataset(not_xml)
         except TypeError:
             assert True
         else:  # pragma: no cover
@@ -70,7 +70,7 @@ class TestDatasets(object):
     def test_dataset_tree(self):
         """Test Dataset creation with an etree that is not valid IATI data."""
         tree = iati.core.tests.utilities.XML_TREE_VALID
-        data = iati.core.data.Dataset(tree)
+        data = iati.core.Dataset(tree)
 
         assert etree.tostring(data.xml_tree, pretty_print=True) == etree.tostring(tree, pretty_print=True)
         assert data.xml_str == etree.tostring(tree, pretty_print=True)

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -19,10 +19,10 @@ class TestDefault(object):
         name = 'Country'
         codelist = iati.core.default.codelist(name)
 
-        assert isinstance(codelist, iati.core.codelists.Codelist)
+        assert isinstance(codelist, iati.core.Codelist)
         assert codelist.name == name
         for code in codelist.codes:
-            assert isinstance(code, iati.core.codelists.Code)
+            assert isinstance(code, iati.core.Code)
 
     @pytest.mark.parametrize("name", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_default_codelist_invalid(self, name):
@@ -47,7 +47,7 @@ class TestDefault(object):
         assert isinstance(codelists, dict)
         assert len(codelists) == 62
         for _, codelist in codelists.items():
-            assert isinstance(codelist, iati.core.codelists.Codelist)
+            assert isinstance(codelist, iati.core.Codelist)
 
     def test_default_schemas(self):
         """Check that the default Schemas are correct.
@@ -62,4 +62,4 @@ class TestDefault(object):
         assert isinstance(schemas, dict)
         assert len(schemas) == 1
         for _, schema in schemas.items():
-            assert isinstance(schema, iati.core.schemas.Schema)
+            assert isinstance(schema, iati.core.Schema)

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -15,15 +15,15 @@ class TestSchemas(object):
         """Create a very basic Schema.
 
         Returns:
-            iati.core.schemas.Schema: A Schema that has been initialised with basic values.
+            iati.core.Schema: A Schema that has been initialised with basic values.
         """
         schema_name = iati.core.tests.utilities.SCHEMA_NAME_VALID
 
-        return iati.core.schemas.Schema(name=schema_name)
+        return iati.core.Schema(name=schema_name)
 
     def test_schema_default_attributes(self):
         """Check a Schema's default attributes are correct"""
-        schema = iati.core.schemas.Schema()
+        schema = iati.core.Schema()
 
         assert schema.name is None
 
@@ -35,7 +35,7 @@ class TestSchemas(object):
             Check for type errors when the type is incorrect.
         """
         try:
-            _ = iati.core.schemas.Schema(invalid_name)
+            _ = iati.core.Schema(invalid_name)
         except TypeError:
             assert True
         else:  # pragma: no cover
@@ -139,7 +139,7 @@ class TestSchemas(object):
         """Check that it is possible to add Codelists to the Schema."""
         codelist_name = "a test Codelist name"
         schema = schema_initialised
-        codelist = iati.core.codelists.Codelist(codelist_name)
+        codelist = iati.core.Codelist(codelist_name)
 
         schema.codelists.add(codelist)
 
@@ -149,7 +149,7 @@ class TestSchemas(object):
         """Check that it is not possible to add the same Codelist to a Schema multiple times."""
         codelist_name = "a test Codelist name"
         schema = schema_initialised
-        codelist = iati.core.codelists.Codelist(codelist_name)
+        codelist = iati.core.Codelist(codelist_name)
 
         schema.codelists.add(codelist)
         schema.codelists.add(codelist)
@@ -160,8 +160,8 @@ class TestSchemas(object):
         """Check that it is not possible to add multiple functionally identical Codelists to a Schema."""
         codelist_name = "a test Codelist name"
         schema = schema_initialised
-        codelist = iati.core.codelists.Codelist(codelist_name)
-        codelist2 = iati.core.codelists.Codelist(codelist_name)
+        codelist = iati.core.Codelist(codelist_name)
+        codelist2 = iati.core.Codelist(codelist_name)
 
         schema.codelists.add(codelist)
         schema.codelists.add(codelist2)

--- a/iati/core/tests/test_utilities.py
+++ b/iati/core/tests/test_utilities.py
@@ -12,7 +12,7 @@ class TestUtilities(object):
     @pytest.fixture
     def schema_base_tree(self):
         """Return schema_base_tree."""
-        return iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)._schema_base_tree
+        return iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)._schema_base_tree
 
     def test_add_namespace_schema_new(self, schema_base_tree):
         """Check that an additional namespace can be added to a Schema.

--- a/iati/core/utilities.py
+++ b/iati/core/utilities.py
@@ -18,7 +18,7 @@ def add_namespace(tree, new_ns_name, new_ns_uri):
         new_ns_uri (str): The URI for the new namespace. Must be non-empty and valid against https://www.ietf.org/rfc/rfc2396.txt
 
     Returns:
-        iati.core.schemas.Schema: The provided Schema, modified to include the specified namespace.
+        iati.core.Schema: The provided Schema, modified to include the specified namespace.
 
     Raises:
         TypeError: If an attempt is made to add a namespace to something other than a Schema.
@@ -86,7 +86,7 @@ def convert_tree_to_schema(tree):
     Warning:
         Should raise exceptions when there are errors during execution.
 
-        Needs to better distinguish between an `etree.XMLSchema` and an `iati.core.schemas.Schema`.
+        Needs to better distinguish between an `etree.XMLSchema` and an `iati.core.Schema`.
 
         Does not fully hide the lxml internal workings.
 

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -13,36 +13,36 @@ class TestValidate(object):
 
     def test_basic_validation_valid(self):
         """Perform a super simple data validation against a valid Dataset."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid(self):
         """Perform a super simple data validation against an invalid Dataset."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element(self):
         """Perform a super simple data validation against a Dataset that is invalid due to a missing required element."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element_from_common(self):
         """Perform a super simple data validation against a Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_valid(self):
         """Perform data validation against valid IATI XML that has valid Codelist values."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
         schema.codelists.add(codelist)
@@ -51,8 +51,8 @@ class TestValidate(object):
 
     def test_basic_validation_codelist_invalid(self):
         """Perform data validation against valid IATI XML that has invalid Codelist values."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
         schema.codelists.add(codelist)
@@ -61,8 +61,8 @@ class TestValidate(object):
 
     def test_basic_validation_codelist_valid_from_common(self):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd"""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
         schema.codelists.add(codelist)
@@ -71,8 +71,8 @@ class TestValidate(object):
 
     def test_basic_validation_codelist_invalid_from_common(self):
         """Perform data validation against valid IATI XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd"""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
         schema.codelists.add(codelist)
@@ -81,8 +81,8 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_default_implicit(self):
         """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -95,8 +95,8 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_default_implicit_invalid_code(self):
         """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set. The code is invalid."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -109,8 +109,8 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_default_explicit(self):
         """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as the default value."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -123,8 +123,8 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_non_default(self):
         """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_NON_DEFAULT)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_NON_DEFAULT)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -137,8 +137,8 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_user_defined(self):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -151,8 +151,8 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_user_defined_with_uri_readable(self):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -169,8 +169,8 @@ class TestValidate(object):
         Todo:
             Check that this is a legitimate check to be performed, given the contents and guidance given in the Standard.
         """
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -187,8 +187,8 @@ class TestValidate(object):
         Todo:
             Remove xfail and work on functionality to fully fetch and parse user-defined codelists after higher priority functionality is finished.
         """
-        data = iati.core.data.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE)
-        schema = iati.core.schemas.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE)
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']

--- a/iati/validate.py
+++ b/iati/validate.py
@@ -11,8 +11,8 @@ def is_valid(dataset, schema):
     """Determine whether a given Dataset is valid against the specified Schema.
 
     Args:
-        dataset (iati.core.data.Dataset): The Dataset to check validity of.
-        schema (iati.core.schemas.Schema): The Schema to validate the Dataset against.
+        dataset (iati.core.Dataset): The Dataset to check validity of.
+        schema (iati.core.Schema): The Schema to validate the Dataset against.
 
     Warning:
         Parameters are likely to change in some manner.


### PR DESCRIPTION
Simplifies the way functions are called. This effectively
renames library functions as follows:

`iati.core.codelists.Code` -> `iati.core.Code`
`iati.core.codelists.Codelist` -> `iati.core.Codelist`
`iati.core.data.Dataset` -> `iati.core.Dataset`
`iati.core.rulesets.Rule` -> `iati.core.Rule`
`iati.core.rulesets.Ruleset` -> `iati.core.Ruleset`
`iati.core.schema.Schema` -> `iati.core.Schema`