### PR TITLE
Fix pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ add_select=D212,D404
 convention=pep257
 
 [tool:pytest]
--testpaths = iati
+testpaths = iati


### PR DESCRIPTION
The unnecessary '-' character was removed.