### PR TITLE
[#42] Refector to align function names with outputs

### DIFF
--- a/LICENSES-3RD-PARTY.txt
+++ b/LICENSES-3RD-PARTY.txt
@@ -418,6 +418,7 @@ Public License instead of this License.
     - pytest, Copyright (c) 2004-2016 Holger Krekel and others
     - pytest-cov, Copyright (c) 2010 Meme Dough
     - radon, Copyright (c) 2012-2014 Michele Lacchia
+    - six, Copyright (c) 2010-2015 Benjamin Peterson
     - sphinx_rtd_theme, Copyright (c) 2013 Dave Snider
 -----------------------------------------------------------------------------
 

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -243,10 +243,8 @@ def load_as_bytes(path):
     Returns:
         bytes: The contents of the file at the specified location.
 
-    Warning:
-        Should raise Exceptions when there are problems loading the requested data.
-
     Todo:
+        Should raise Exceptions when there are problems loading the requested data.
         Add error handling for when the specified file does not exist.
         Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).
 
@@ -263,10 +261,8 @@ def load_as_string(path):
     Returns:
         str (python3) / unicode (python2): The contents of the file at the specified location.
 
-    Warning:
-        Should raise Exceptions when there are problems loading the requested data.
-
     Todo:
+        Should raise Exceptions when there are problems loading the requested data.
         Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).
 
     """

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -234,6 +234,26 @@ def get_path_for_version(path, version=None):
     return os.path.join(get_folder_path_for_version(version), path)
 
 
+def load_as_bytes(path):
+    """Load a resource at the specified path into a bytes object.
+
+    Args:
+        path (str): The path to the file that is to be read in.
+
+    Returns:
+        bytes: The contents of the file at the specified location.
+
+    Warning:
+        Should raise Exceptions when there are problems loading the requested data.
+
+    Todo:
+        Add error handling for when the specified file does not exist.
+        Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).
+
+    """
+    return pkg_resources.resource_string(PACKAGE, path)
+
+
 def load_as_string(path):
     """Load a resource at the specified path into a string.
 
@@ -241,16 +261,16 @@ def load_as_string(path):
         path (str): The path to the file that is to be read in.
 
     Returns:
-        str: The contents of the file at the specified location.
+        str (python3) / unicode (python2): The contents of the file at the specified location.
 
     Warning:
         Should raise Exceptions when there are problems loading the requested data.
 
     Todo:
-        Add error handling for when the specified file does not exist.
+        Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).
 
     """
-    return pkg_resources.resource_string(PACKAGE, path)
+    return load_as_bytes(path).decode('utf-8')
 
 
 def load_as_tree(path):

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -1,7 +1,7 @@
 """A module containing tests for the library implementation of accessing resources."""
 from lxml import etree
 import pytest
-from six import string_types
+import six
 import iati.core.resources
 
 
@@ -104,7 +104,7 @@ class TestResources(object):
 
         result = iati.core.resources.load_as_string(path_test_data)
 
-        assert isinstance(result, string_types)
+        assert isinstance(result, six.string_types)
         assert result == 'This is a string that is not valid XML\n'
 
     def test_resource_filename(self):

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -1,6 +1,7 @@
 """A module containing tests for the library implementation of accessing resources."""
 from lxml import etree
 import pytest
+from six import string_types
 import iati.core.resources
 
 
@@ -87,6 +88,24 @@ class TestResources(object):
         assert path[-4:] == iati.core.resources.FILE_CODELIST_EXTENSION
         assert path.count(iati.core.resources.FILE_CODELIST_EXTENSION) == 1
         assert iati.core.resources.PATH_CODELISTS in path
+
+    def test_load_as_bytes(self):
+        """Test that resources.load_as_bytes returns a bytes object with the expected content."""
+        path_test_data = iati.core.resources.get_test_data_path('invalid')
+
+        result = iati.core.resources.load_as_bytes(path_test_data)
+
+        assert isinstance(result, bytes)
+        assert result == 'This is a string that is not valid XML\n'.encode()
+
+    def test_load_as_string(self):
+        """Test that resources.load_as_string returns a string (python3) or unicode (python2) object with the expected content."""
+        path_test_data = iati.core.resources.get_test_data_path('invalid')
+
+        result = iati.core.resources.load_as_string(path_test_data)
+
+        assert isinstance(result, string_types)
+        assert result == 'This is a string that is not valid XML\n'
 
     def test_resource_filename(self):
         """Check that resource file names are found correctly.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,10 +19,13 @@ radon==2.0.2 # rq.filter: <3.0
 pytest==3.0.5 # rq.filter: <4.0
 pytest-cov==2.4.0 # rq.filter: <3.0
 
+# python2/python3 compatibility library
+six==1.10.0
+
 #
 # distribution requirements
 #
 
 # documentation
 Sphinx==1.5.2 # rq.filter: <2.0
-sphinx_rtd_theme==0.1.9 # rq.filter: <1.0		
+sphinx_rtd_theme==0.1.9 # rq.filter: <1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ pytest==3.0.5 # rq.filter: <4.0
 pytest-cov==2.4.0 # rq.filter: <3.0
 
 # python2/python3 compatibility library
-six==1.10.0
+six==1.10.0 # rq.filter: <2.0
 
 #
 # distribution requirements


### PR DESCRIPTION
Ensures iati.core.resources.load_as_string now returns a string,
whilst adding iati.core.resources.load_as_bytes to return a bytes
object. Adds tests for both functions.