### PR TITLE
Improve test resources clarity

### DIFF
--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -7,9 +7,9 @@ The `get_*_path[s](name)` functions provide information about where to locate pa
 The `load_as_*(path)` functions load the contents of a file at the specified path and return it in the specified format.
 
 Example:
-    To load a test XML file located in `my_test_file` and use it to create a `Dataset`:
+    To load a test XML file located in `my_test_file` and use it to create a `Dataset`::
 
-        $ dataset = iati.core.Dataset(iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('my_test_file')))
+        dataset = iati.core.Dataset(iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('my_test_file')))
 
 Note:
     `pkg_resources` is used to allow resources to be located however the package is distributed. If using the standard `os` functionality, resources may not be locatable if, for example, the package is distributed as an egg.

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -1,6 +1,18 @@
 """A module to provide a way of locating resources within the IATI library.
 
-`pkg_resources` is used to allow resources to be located however the package is distributed. If using the standard `os` functionality, resources may not be locatable if, for example, the package is distributed as an egg.
+There are two key groups of functions within this module: `get_*_path[s]()` and `load_as_*()`.
+
+The `get_*_path[s](name)` functions provide information about where to locate particular types of resources with a provided name.
+
+The `load_as_*(path)` functions load the contents of a file at the specified path and return it in the specified format.
+
+Example:
+    To load a test XML file located in `my_test_file` and use it to create a `Dataset`:
+
+        $ dataset = iati.core.Dataset(iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('my_test_file')))
+
+Note:
+    `pkg_resources` is used to allow resources to be located however the package is distributed. If using the standard `os` functionality, resources may not be locatable if, for example, the package is distributed as an egg.
 
 Warning:
     The contents of this module are likely to change. This is due to them expecting that there is a single version of the Standard. When this assumption changes, so will the contents of this module.

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -131,6 +131,31 @@ def get_codelist_path(codelist_name, version=None):
     return get_path_for_version(os.path.join(PATH_CODELISTS, '{0}'.format(codelist_name) + FILE_CODELIST_EXTENSION), version)
 
 
+def get_schema_path(name, version=None):
+    """Determine the path of a schema with the given name.
+
+    Args:
+        name (str): The name of the schema to locate.
+        version (str): The version of the Standard to return the Schemas for. Defaults to None. This means that paths to the latest version of the Schemas are returned.
+
+    Returns:
+        str: The path to a file containing the specified schema.
+
+    Note:
+        Does not check whether the specified schema actually exists.
+
+    Warning:
+        Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
+
+    Todo:
+        Handle versions of the standard other than 2.02.
+
+        Test this.
+
+    """
+    return get_path_for_version(os.path.join(PATH_SCHEMAS, '{0}'.format(name) + FILE_SCHEMA_EXTENSION), version)
+
+
 def get_test_data_path(name, version=None):
     """Determine the path of an IATI data file with the given filename.
 
@@ -174,31 +199,6 @@ def get_folder_name_for_version(version=None):
         return version.replace('.', '')
     else:
         raise ValueError("Version {} is not a valid version of the IATI Standard.".format(version))
-
-
-def get_schema_path(name, version=None):
-    """Determine the path of a schema with the given name.
-
-    Args:
-        name (str): The name of the schema to locate.
-        version (str): The version of the Standard to return the Schemas for. Defaults to None. This means that paths to the latest version of the Schemas are returned.
-
-    Returns:
-        str: The path to a file containing the specified schema.
-
-    Note:
-        Does not check whether the specified schema actually exists.
-
-    Warning:
-        Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
-
-    Todo:
-        Handle versions of the standard other than 2.02.
-
-        Test this.
-
-    """
-    return get_path_for_version(os.path.join(PATH_SCHEMAS, '{0}'.format(name) + FILE_SCHEMA_EXTENSION), version)
 
 
 def get_folder_path_for_version(version=None):

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -3,9 +3,9 @@
 A large number of constants containing example file content are contained. These constants are named from left to right, with general properties first, then leading into more specific information. These names indicate what they are used for.
 
 Example:
-    To load a file called `NAME_OF_FILE_TO_LOAD` into a string:
+    To load a file called `NAME_OF_FILE_TO_LOAD` into a string::
 
-        $ CONSTANT_NAME = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(NAME_OF_FILE_TO_LOAD))
+        CONSTANT_NAME = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(NAME_OF_FILE_TO_LOAD))
 
 Note:
     The current method of managing test data is known to be sub-optimal. Suggestions for better methods that satisfy requirements are appreciated!

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -39,26 +39,26 @@ XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON = iati.core.resources.load_
 """A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
 
 XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_valid_code_from_common'))
-"""A string contains valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value on the appropriate Codelist."""
+"""A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value on the appropriate Codelist."""
 XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_invalid_code_from_common'))
-"""A string contains valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value that is not on the appropriate Codelist."""
+"""A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value that is not on the appropriate Codelist."""
 
 XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_explicit'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Explicitly defines default vocab and uses code from that list."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines default vocab and uses code from that list."""
 XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_implicit'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code from that list."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code from that list."""
 XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_implicit_invalid_code'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code not in list."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code not in list."""
 XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_non_default'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Explicitly defines non-default vocab and uses code from that list."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines non-default vocab and uses code from that list."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined_with_uri_readable'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code from this list."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code from this list."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined_with_uri_readable_bad_code'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code not in list."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code not in list."""
 XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined_with_uri_unreadable'))
-"""A string contains valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and not machine readable."""
+"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and not machine readable."""
 
 XML_TREE_VALID = etree.fromstring(XML_STR_VALID_NOT_IATI)
 """An etree that is not valid IATI data."""

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -3,9 +3,10 @@
 A large number of constants containing example file content are contained. These constants are named from left to right, with general properties first, then leading into more specific information. These names indicate what they are used for.
 
 Example:
-    To load a file called `NAME_OF_FILE_TO_LOAD` into a string::
+    To load a file into a string::
 
-        CONSTANT_NAME = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(NAME_OF_FILE_TO_LOAD))
+        name_of_file = 'a-file-name-without-the-extension'
+        CONSTANT_NAME = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(name_of_file))
 
 Note:
     The current method of managing test data is known to be sub-optimal. Suggestions for better methods that satisfy requirements are appreciated!

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -1,5 +1,15 @@
 """A module containing utility constants and functions for tests.
 
+A large number of constants containing example file content are contained. These constants are named from left to right, with general properties first, then leading into more specific information. These names indicate what they are used for.
+
+Example:
+    To load a file called `NAME_OF_FILE_TO_LOAD` into a string:
+
+        $ CONSTANT_NAME = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(NAME_OF_FILE_TO_LOAD))
+
+Note:
+    The current method of managing test data is known to be sub-optimal. Suggestions for better methods that satisfy requirements are appreciated!
+
 Todo:
     Add versions of constants that are valid for differing schema versions.
 


### PR DESCRIPTION
It was noted that it was challenging to understand each how `resources.py` works, and how to load in test data.

This improves documentation and fixes method ordering so that clarity is improved.