### PR TITLE
Improvements to iati.core.schema.Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,16 @@ Once installed, the library provides functionality to represent IATI Schemas, Co
 
 ### Loading an XSD Schema
 
-The `.xsd` schema file should be stored in the folder: `iati.core/iati/core/resources/schemas/202/`
+A number of default IATI `.xsd` schema files are included as part of the library. They are stored in the folder: `iati.core/iati/core/resources/schemas/202/`
 
-The following example loads the included IATI v2.02 schema at:  `iati.core/iati/core/resources/schemas/202/iati-activities-schema.xsd`.
+The following example loads the default IATI v2.02 `iati-activities-schema.xsd` schema:
 
 ```
 import iati.core.default
 schema = iati.core.default.schema('iati-activities-schema')
 ```
+
+Helper functions will be written in due course to return all xpaths within a schema, as well as documentation for each element.
 
 ### Loading codelists
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following example loads the included IATI v2.02 schema at:  `iati.core/iati/
 
 ```
 import iati.core.schemas
-schema = iati.core.Schema(name='iati-activities-schema')
+schema = iati.core.ActivitySchema(name='iati-activities-schema')
 ```
 
 ### Loading codelists

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The `.xsd` schema file should be stored in the folder: `iati.core/iati/core/reso
 The following example loads the included IATI v2.02 schema at:  `iati.core/iati/core/resources/schemas/202/iati-activities-schema.xsd`.
 
 ```
-import iati.core.schemas
-schema = iati.core.ActivitySchema(name='iati-activities-schema')
+import iati.core.default
+schema = iati.core.default.schema('iati-activities-schema')
 ```
 
 ### Loading codelists

--- a/iati/core/__init__.py
+++ b/iati/core/__init__.py
@@ -2,4 +2,4 @@
 from .codelists import Code, Codelist
 from .data import Dataset
 from .rulesets import Rule, Ruleset
-from .schemas import Schema
+from .schemas import ActivitySchema, OrganisationSchema, Schema

--- a/iati/core/__init__.py
+++ b/iati/core/__init__.py
@@ -2,4 +2,4 @@
 from .codelists import Code, Codelist
 from .data import Dataset
 from .rulesets import Rule, Ruleset
-from .schemas import ActivitySchema, OrganisationSchema, Schema
+from .schemas import ActivitySchema, OrganisationSchema

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -111,7 +111,7 @@ def schemas(bypass_cache=False):
         bypass_cache (bool): Whether the cache should be bypassed, instead reloading data from disk even if it's already been loaded.
 
     Returns:
-        dict: A dictionary containing all the Schemas for versions of the Standard. The version of the Standard is the key. An iati.core.Schema() is each value.
+        dict: A dictionary containing all the Schemas for versions of the Standard. The name of the schema the key. An iati.core.Schema() is each value.
 
     Warning:
         The `bypass_cache` parameter could potentially be implemented in a cleaner manner. It also shouldn't really exist until a clear use-case is defined - changes elsewhere in the library may make it redundant.
@@ -127,13 +127,23 @@ def schemas(bypass_cache=False):
 
         Needs to handle multiple versions of the Schemas. Versions could perhaps be placed within a nested dictionary, with the version number as the key.
 
+        Refactor to remove duplicate code.
+
     """
-    paths = iati.core.resources.find_all_schema_paths()
+    paths = iati.core.resources.find_all_activity_schema_paths()
 
     for path in paths:
         name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
         if (name not in _SCHEMAS.keys()) or bypass_cache:
             schema = iati.core.ActivitySchema(path)
+            _SCHEMAS[name] = schema
+
+    paths = iati.core.resources.find_all_organisation_schema_paths()
+
+    for path in paths:
+        name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
+        if (name not in _SCHEMAS.keys()) or bypass_cache:
+            schema = iati.core.OrganisationSchema(path)
             _SCHEMAS[name] = schema
 
     return _SCHEMAS

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -83,7 +83,7 @@ def codelists(version=None, bypass_cache=False):
         Add a function to return a single Codelist by name.
 
     """
-    paths = iati.core.resources.find_all_codelist_paths()
+    paths = iati.core.resources.get_all_codelist_paths()
 
     for path in paths:
         _, filename = os.path.split(path)
@@ -129,8 +129,8 @@ def schemas(bypass_cache=False):
 
     """
     schema_paths_by_type = {
-        'activity': iati.core.resources.find_all_activity_schema_paths(),
-        'organisation': iati.core.resources.find_all_organisation_schema_paths()
+        'activity': iati.core.resources.get_all_activity_schema_paths(),
+        'organisation': iati.core.resources.get_all_organisation_schema_paths()
     }
 
     for schema_type, schema_paths in schema_paths_by_type.items():

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -117,8 +117,6 @@ def schemas(bypass_cache=False):
         The `bypass_cache` parameter could potentially be implemented in a cleaner manner. It also shouldn't really exist until a clear use-case is defined - changes elsewhere in the library may make it redundant.
 
     Todo:
-        Handle the difference between Organisation and Activity Schemas - i.e. load ActivitySchema or OrganisationSchema, rather than always ActivitySchema
-
         Consider the Schema that defines the format of Codelists.
 
         Test a cache bypass where data is updated.

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -113,6 +113,7 @@ def activity_schemas():
 
     Todo:
         Handle a `bypass_cache` parameter.
+
     """
     output = {}
     for version in iati.core.constants.STANDARD_VERSIONS:
@@ -130,6 +131,7 @@ def organisation_schemas():
 
     Todo:
         Handle a `bypass_cache` parameter.
+
     """
     output = {}
     for version in iati.core.constants.STANDARD_VERSIONS:
@@ -149,6 +151,7 @@ def schemas():
         Consider the Schema that defines the format of Codelists.
 
         Needs to handle multiple versions of the Schemas. This will probably involve passing in a version as a param, which should tidy up the function too.
+
     """
     schemas_by_type_and_version = {
         'activity': activity_schemas(),
@@ -158,8 +161,9 @@ def schemas():
     latest_version = iati.core.constants.STANDARD_VERSION_LATEST
     for _, schemas_by_version in schemas_by_type_and_version.items():
         schema_object = schemas_by_version[latest_version]
-        name = schema_object._source_path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
-        if (name not in _SCHEMAS.keys()):
+        schema_filename = schema_object._source_path.split(os.sep).pop()
+        name = schema_filename[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
+        if name not in _SCHEMAS.keys():
             _SCHEMAS[name] = schema_object
 
     return _SCHEMAS

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -111,7 +111,7 @@ def schemas(bypass_cache=False):
         bypass_cache (bool): Whether the cache should be bypassed, instead reloading data from disk even if it's already been loaded.
 
     Returns:
-        dict: A dictionary containing all the Schemas for versions of the Standard. The name of the schema the key. An iati.core.Schema() is each value.
+        dict: A dictionary containing all the Schemas for versions of the Standard. This returns the name of the Schema (as the key) and a subclass of iati.core.schemas.Schema() (as the value).
 
     Warning:
         The `bypass_cache` parameter could potentially be implemented in a cleaner manner. It also shouldn't really exist until a clear use-case is defined - changes elsewhere in the library may make it redundant.

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -127,24 +127,21 @@ def schemas(bypass_cache=False):
 
         Needs to handle multiple versions of the Schemas. Versions could perhaps be placed within a nested dictionary, with the version number as the key.
 
-        Refactor to remove duplicate code.
-
     """
-    paths = iati.core.resources.find_all_activity_schema_paths()
+    schema_paths_by_type = {
+        'activity': iati.core.resources.find_all_activity_schema_paths(),
+        'organisation': iati.core.resources.find_all_organisation_schema_paths()
+    }
 
-    for path in paths:
-        name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
-        if (name not in _SCHEMAS.keys()) or bypass_cache:
-            schema = iati.core.ActivitySchema(path)
-            _SCHEMAS[name] = schema
-
-    paths = iati.core.resources.find_all_organisation_schema_paths()
-
-    for path in paths:
-        name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
-        if (name not in _SCHEMAS.keys()) or bypass_cache:
-            schema = iati.core.OrganisationSchema(path)
-            _SCHEMAS[name] = schema
+    for schema_type, schema_paths in schema_paths_by_type.items():
+        for path in schema_paths:
+            name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
+            if (name not in _SCHEMAS.keys()) or bypass_cache:
+                if schema_type == 'activity':
+                    schema = iati.core.ActivitySchema(path)
+                elif schema_type == 'organisation':
+                    schema = iati.core.OrganisationSchema(path)
+                _SCHEMAS[name] = schema
 
     return _SCHEMAS
 

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -105,7 +105,7 @@ This removes the need to repeatedly load a Schema from disk each time it is acce
 
 
 def schemas(bypass_cache=False):
-    """Locate all the default Schemas and return them within a dictionary.
+    """Locate all the default IATI Schemas and return them within a dictionary.
 
     Args:
         bypass_cache (bool): Whether the cache should be bypassed, instead reloading data from disk even if it's already been loaded.
@@ -147,6 +147,12 @@ def schema(name, version=None):
     Args:
         name (str): The name of the Schema to locate.
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
+
+    Returns:
+        iati.core.schema.Schema (or subclass): An instance of the schema corresponding to the input name and version.
+
+    Raises:
+        KeyError: If the input schema name is not found as part of the default IATI Schemas.
 
     Todo:
         Needs to handle multiple versions of the Schemas. At present, only the latest version can be returned.

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -139,22 +139,14 @@ def organisation_schemas():
     return output
 
 
-def schemas(bypass_cache=False):
+def schemas():
     """Locate all the default IATI Schemas and return them within a dictionary.
-
-    Args:
-        bypass_cache (bool): Whether the cache should be bypassed, instead reloading data from disk even if it's already been loaded.
 
     Returns:
         dict: A dictionary containing all the Schemas for versions of the Standard. This returns the name of the Schema (as the key) and a subclass of iati.core.schemas.Schema() (as the value).
 
-    Warning:
-        The `bypass_cache` parameter could potentially be implemented in a cleaner manner. It also shouldn't really exist until a clear use-case is defined - changes elsewhere in the library may make it redundant.
-
     Todo:
         Consider the Schema that defines the format of Codelists.
-
-        Handle the `bypass_cache` parameter (and test a cache bypass where data is updated).
 
         Needs to handle multiple versions of the Schemas. This will probably involve passing in a version as a param, which should tidy up the function too.
     """

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -158,7 +158,7 @@ def schemas():
     latest_version = iati.core.constants.STANDARD_VERSION_LATEST
     for _, schemas_by_version in schemas_by_type_and_version.items():
         schema_object = schemas_by_version[latest_version]
-        name = schema_object.source_path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
+        name = schema_object._source_path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
         if (name not in _SCHEMAS.keys()):
             _SCHEMAS[name] = schema_object
 

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -105,7 +105,7 @@ This removes the need to repeatedly load a Schema from disk each time it is acce
 
 
 def schemas(bypass_cache=False):
-    """Locate the default Schemas.
+    """Locate all the default Schemas and return them within a dictionary.
 
     Args:
         bypass_cache (bool): Whether the cache should be bypassed, instead reloading data from disk even if it's already been loaded.
@@ -119,7 +119,7 @@ def schemas(bypass_cache=False):
     Todo:
         Allow creation of Schemas by XML rather than name.
 
-        Handle the difference between Organisation and Activity Schemas - i.e. load ActivitySchema or OrganisationSchema, rather than Schema
+        Handle the difference between Organisation and Activity Schemas - i.e. load ActivitySchema or OrganisationSchema, rather than always ActivitySchema
 
         Consider the Schema that defines the format of Codelists.
 
@@ -127,13 +127,35 @@ def schemas(bypass_cache=False):
 
         Load the Schemas.
 
+        Needs to handle multiple versions of the Schemas. Versions could perhaps be placed within a nested dictionary, with the version number as the key.
+
     """
     paths = iati.core.resources.find_all_schema_paths()
 
     for path in paths:
         name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
         if (name not in _SCHEMAS.keys()) or bypass_cache:
-            schema = iati.core.Schema(name)
+            schema = iati.core.ActivitySchema(path)
             _SCHEMAS[name] = schema
 
     return _SCHEMAS
+
+
+def schema(name, version=None):
+    """Return a default Schema with the specified name for the specified version of the Standard.
+
+    Args:
+        name (str): The name of the Schema to locate.
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
+
+    Todo:
+        Needs to handle multiple versions of the Schemas. At present, only the latest version can be returned.
+
+    """
+
+    try:
+        return schemas()[name]
+    except KeyError:
+        msg = 'There is no default Schema in version {0} of the Standard with the name {1}.'.format(version, name)
+        iati.core.utilities.log_warning(msg)
+        raise ValueError(msg)

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -117,8 +117,6 @@ def schemas(bypass_cache=False):
         The `bypass_cache` parameter could potentially be implemented in a cleaner manner. It also shouldn't really exist until a clear use-case is defined - changes elsewhere in the library may make it redundant.
 
     Todo:
-        Allow creation of Schemas by XML rather than name.
-
         Handle the difference between Organisation and Activity Schemas - i.e. load ActivitySchema or OrganisationSchema, rather than always ActivitySchema
 
         Consider the Schema that defines the format of Codelists.

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -119,7 +119,7 @@ def schemas(bypass_cache=False):
     Todo:
         Allow creation of Schemas by XML rather than name.
 
-        Handle the difference between Organisation and Activity Schemas.
+        Handle the difference between Organisation and Activity Schemas - i.e. load ActivitySchema or OrganisationSchema, rather than Schema
 
         Consider the Schema that defines the format of Codelists.
 

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -136,10 +136,10 @@ def schemas(bypass_cache=False):
             name = path.split(os.sep).pop()[:-len(iati.core.resources.FILE_SCHEMA_EXTENSION)]
             if (name not in _SCHEMAS.keys()) or bypass_cache:
                 if schema_type == 'activity':
-                    schema = iati.core.ActivitySchema(path)
+                    schema_object = iati.core.ActivitySchema(path)
                 elif schema_type == 'organisation':
-                    schema = iati.core.OrganisationSchema(path)
-                _SCHEMAS[name] = schema
+                    schema_object = iati.core.OrganisationSchema(path)
+                _SCHEMAS[name] = schema_object
 
     return _SCHEMAS
 
@@ -161,7 +161,6 @@ def schema(name, version=None):
         Needs to handle multiple versions of the Schemas. At present, only the latest version can be returned.
 
     """
-
     try:
         return schemas()[name]
     except KeyError:

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -169,7 +169,7 @@ def schema(name, version=None):
     """Return a default Schema with the specified name for the specified version of the Standard.
 
     Args:
-        name (str): The name of the Schema to locate.
+        name (str): The name of the Schema to locate. Current values are 'iati-activities-schema' or 'iati-organisations-schema'.
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
 
     Returns:

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -119,7 +119,7 @@ def get_all_activity_schema_paths(version=None):
     """Find the paths for all activity schemas.
 
     Args:
-        version (str): The version of the Standard to return the activity Schemas for. Defaults to None. This means that paths to the latest version of the activity Schemas are returned.
+        version (str): The version of the Standard to return the activity schemas for. Defaults to None. This means that paths to the latest version of the activity Schemas are returned.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
@@ -143,7 +143,7 @@ def get_all_organisation_schema_paths(version=None):
     """Find the paths for all organisation schemas.
 
     Args:
-        version (str): The version of the Standard to return the organisation Schemas for. Defaults to None. This means that paths to the latest version of the activity Schemas are returned.
+        version (str): The version of the Standard to return the organisation schemas for. Defaults to None. This means that paths to the latest version of the activity Schemas are returned.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -109,10 +109,13 @@ def find_all_schema_paths(version=None):
     Todo:
         Handle versions, including errors.
 
-        Implement for more than a single specified activity schema.
+        Potentially add the IATI codelist schema.
 
     """
-    return [get_schema_path(FILE_SCHEMA_ACTIVITY_NAME, version)]
+    return [
+        get_schema_path(FILE_SCHEMA_ACTIVITY_NAME, version),
+        get_schema_path(FILE_SCHEMA_ORGANISATION_NAME, version)
+    ]
 
 
 def get_codelist_path(codelist_name, version=None):

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -125,7 +125,7 @@ def get_all_activity_schema_paths(version=None):
         ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
-        list: A list of paths to all of the activity Schemas at the specified version of the Standard.
+        list of str: A list of paths to all of the activity Schemas at the specified version of the Standard.
 
     Warning:
         Further exploration needs to be undertaken in how to handle multiple versions of the Standard.

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -112,10 +112,55 @@ def find_all_schema_paths(version=None):
         Potentially add the IATI codelist schema.
 
     """
-    return [
-        get_schema_path(FILE_SCHEMA_ACTIVITY_NAME, version),
-        get_schema_path(FILE_SCHEMA_ORGANISATION_NAME, version)
-    ]
+    return find_all_activity_schema_paths(version) + find_all_organisation_schema_paths(version)
+
+
+def find_all_activity_schema_paths(version=None):
+    """Find the paths for all activity schemas.
+
+    Args:
+        version (str): The version of the Standard to return the activity Schemas for. Defaults to None. This means that paths to the latest version of the activity Schemas are returned.
+
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
+
+    Returns:
+        list: A list of paths to all of the activity Schemas at the specified version of the Standard.
+
+    Warning:
+        Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
+
+    Todo:
+        Handle versions, including errors.
+
+        Potentially add the IATI codelist schema.
+
+    """
+    return [get_schema_path(FILE_SCHEMA_ACTIVITY_NAME, version)]
+
+
+def find_all_organisation_schema_paths(version=None):
+    """Find the paths for all organisation schemas.
+
+    Args:
+        version (str): The version of the Standard to return the organisation Schemas for. Defaults to None. This means that paths to the latest version of the activity Schemas are returned.
+
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
+
+    Returns:
+        list: A list of paths to all of the organisation Schemas at the specified version of the Standard.
+
+    Warning:
+        Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
+
+    Todo:
+        Handle versions, including errors.
+
+        Potentially add the IATI codelist schema.
+
+    """
+    return [get_schema_path(FILE_SCHEMA_ORGANISATION_NAME, version)]
 
 
 def get_codelist_path(codelist_name, version=None):

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -63,7 +63,7 @@ FILE_SCHEMA_EXTENSION = '.xsd'
 """The extension of a file containing a Schema."""
 
 
-def find_all_codelist_paths(version=None):
+def get_all_codelist_paths(version=None):
     """Find the paths for all codelists.
 
     Args:
@@ -91,7 +91,7 @@ def find_all_codelist_paths(version=None):
     return paths_codelists_only
 
 
-def find_all_schema_paths(version=None):
+def get_all_schema_paths(version=None):
     """Find the paths for all schemas.
 
     Args:
@@ -112,10 +112,10 @@ def find_all_schema_paths(version=None):
         Potentially add the IATI codelist schema.
 
     """
-    return find_all_activity_schema_paths(version) + find_all_organisation_schema_paths(version)
+    return get_all_activity_schema_paths(version) + get_all_organisation_schema_paths(version)
 
 
-def find_all_activity_schema_paths(version=None):
+def get_all_activity_schema_paths(version=None):
     """Find the paths for all activity schemas.
 
     Args:
@@ -139,7 +139,7 @@ def find_all_activity_schema_paths(version=None):
     return [get_schema_path(FILE_SCHEMA_ACTIVITY_NAME, version)]
 
 
-def find_all_organisation_schema_paths(version=None):
+def get_all_organisation_schema_paths(version=None):
     """Find the paths for all organisation schemas.
 
     Args:

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -8,11 +8,11 @@ import iati.core.utilities
 
 
 class Schema(object):
-    """Represenation of a Schema as defined within the IATI SSOT.
+    """Represenation of a Schema as defined within the IATI SSOT. This is used as a base class for ActivitySchema and OrganisationSchema.
 
     Attributes:
         codelists (set): The Codelists asspciated with this Schema. This is a read-only attribute.
-        root_element_name (str): The name of the root element within the schema - i.e. 'iati-activities' for the activity schema and 'iati-organisations' for the organisation schema.
+        root_element_name (str): The name of the root element within the XSD schema that the class represents.
 
     Warning:
         The private attribute allowing access to the base Schema Tree is likely to change in determining a good way of accessing the contained schema content.
@@ -52,10 +52,10 @@ class Schema(object):
             Create test instance where the SchemaError is raised.
 
         """
-        self.source_path = path
         self._schema_base_tree = None
         self.codelists = set()
         self.rulesets = set()
+        self.source_path = path
 
         try:
             loaded_tree = iati.core.resources.load_as_tree(path)

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -52,6 +52,7 @@ class Schema(object):
             Create test instance where the SchemaError is raised.
 
         """
+        self.source_path = path
         self._schema_base_tree = None
         self.codelists = set()
         self.rulesets = set()

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -23,6 +23,7 @@ class Schema(object):
         Determine how to distinguish and handle the different types of Schema - activity, organisation, codelist, other.
 
     """
+
     root_element_name = ''
 
     def __init__(self, path):
@@ -167,10 +168,12 @@ class Schema(object):
 
 
 class ActivitySchema(Schema):
+    """Represenation of an IATI Activity Schema as defined within the IATI SSOT."""
+
     root_element_name = 'iati-activities'
-    pass
 
 
 class OrganisationSchema(Schema):
+    """Represenation of an IATI Organisation Schema as defined within the IATI SSOT."""
+
     root_element_name = 'iati-organisations'
-    pass

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -53,9 +53,9 @@ class Schema(object):
 
         """
         self._schema_base_tree = None
+        self._source_path = path
         self.codelists = set()
         self.rulesets = set()
-        self.source_path = path
 
         try:
             loaded_tree = iati.core.resources.load_as_tree(path)

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -59,7 +59,7 @@ class Schema(object):
 
         try:
             loaded_tree = iati.core.resources.load_as_tree(path)
-        except (IOError, OSError):
+        except OSError:
             msg = "Failed to load tree at '{0}' when creating Schema.".format(path)
             iati.core.utilities.log_error(msg)
             raise iati.core.exceptions.SchemaError

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -12,7 +12,7 @@ class Schema(object):
 
     Attributes:
         codelists (set): The Codelists asspciated with this Schema. This is a read-only attribute.
-        root_element_name (str): The name of the root element within the XML Schema that the class represents.
+        ROOT_ELEMENT_NAME (str): The name of the root element within the XML Schema that the class represents.
 
     Warning:
         The private attribute allowing access to the base Schema Tree is likely to change in determining a good way of accessing the contained schema content.
@@ -24,7 +24,7 @@ class Schema(object):
 
     """
 
-    root_element_name = ''
+    ROOT_ELEMENT_NAME = ''
 
     def __init__(self, path):
         """Initialise a Schema.
@@ -172,10 +172,10 @@ class Schema(object):
 class ActivitySchema(Schema):
     """Represenation of an IATI Activity Schema as defined within the IATI SSOT."""
 
-    root_element_name = 'iati-activities'
+    ROOT_ELEMENT_NAME = 'iati-activities'
 
 
 class OrganisationSchema(Schema):
     """Represenation of an IATI Organisation Schema as defined within the IATI SSOT."""
 
-    root_element_name = 'iati-organisations'
+    ROOT_ELEMENT_NAME = 'iati-organisations'

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -19,7 +19,7 @@ class Schema(object):
         The private attribute allowing access to the base Schema Tree is likely to change in determining a good way of accessing the contained schema content.
 
     Todo:
-        Determine a good API for accessing the XMLSchema that the iati.core.ActivitySchema represents.
+        Determine a good API for accessing the XMLSchema that the iati.core.Schema represents.
 
         Determine how to distinguish and handle the different types of Schema - activity, organisation, codelist, other.
 

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -11,7 +11,6 @@ class Schema(object):
     """Represenation of a Schema as defined within the IATI SSOT.
 
     Attributes:
-        name (str): The name of the Schema.
         codelists (set): The Codelists asspciated with this Schema. This is a read-only attribute.
         root_element_name (str): The name of the root element within the schema - i.e. 'iati-activities' for the activity schema and 'iati-organisations' for the organisation schema.
 
@@ -26,15 +25,13 @@ class Schema(object):
     """
     root_element_name = ''
 
-    def __init__(self, name=None):
+    def __init__(self, path):
         """Initialise a Schema.
 
         Args:
-            name (str): The name of the schema being initialised.
-                This name refers to a file contained within the core IATI resources folder.
+            path (str): The path to the schema that is being initialised.
 
         Raises:
-            TypeError: The type of the provided name is incorrect.
             iati.core.exceptions.SchemaError: An error occurred during the creation of the Schema.
 
         Warning:
@@ -54,24 +51,17 @@ class Schema(object):
             Create test instance where the SchemaError is raised.
 
         """
-        self.name = name
         self._schema_base_tree = None
         self.codelists = set()
 
-        if isinstance(name, str):
-            path = iati.core.resources.get_schema_path(self.name)
-            try:
-                loaded_tree = iati.core.resources.load_as_tree(path)
-            except (IOError, OSError):
-                msg = "Failed to load tree at '{0}' when creating Schema.".format(path)
-                iati.core.utilities.log_error(msg)
-                raise iati.core.exceptions.SchemaError
-            else:
-                self._schema_base_tree = loaded_tree
-        elif name is not None:
-            msg = "The name of the Schema is an invalid type. Must be a string, though was a {0}.".format(type(name))
+        try:
+            loaded_tree = iati.core.resources.load_as_tree(path)
+        except (IOError, OSError):
+            msg = "Failed to load tree at '{0}' when creating Schema.".format(path)
             iati.core.utilities.log_error(msg)
-            raise TypeError(msg)
+            raise iati.core.exceptions.SchemaError
+        else:
+            self._schema_base_tree = loaded_tree
 
     def _change_include_to_xinclude(self, tree):
         """Change the method in which common elements are included.

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -8,11 +8,11 @@ import iati.core.utilities
 
 
 class Schema(object):
-    """Represenation of a Schema as defined within the IATI SSOT. This is used as a base class for ActivitySchema and OrganisationSchema.
+    """Represenation of a Schema as defined within the IATI SSOT. This is used as a base class for ActivitySchema and OrganisationSchema and should not be instantiated directly.
 
     Attributes:
         codelists (set): The Codelists asspciated with this Schema. This is a read-only attribute.
-        root_element_name (str): The name of the root element within the XSD schema that the class represents.
+        root_element_name (str): The name of the root element within the XML Schema that the class represents.
 
     Warning:
         The private attribute allowing access to the base Schema Tree is likely to change in determining a good way of accessing the contained schema content.
@@ -30,7 +30,7 @@ class Schema(object):
         """Initialise a Schema.
 
         Args:
-            path (str): The path to the schema that is being initialised.
+            path (str): The path to the Schema that is being initialised.
 
         Raises:
             iati.core.exceptions.SchemaError: An error occurred during the creation of the Schema.

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -13,16 +13,18 @@ class Schema(object):
     Attributes:
         name (str): The name of the Schema.
         codelists (set): The Codelists asspciated with this Schema. This is a read-only attribute.
+        root_element_name (str): The name of the root element within the schema - i.e. 'iati-activities' for the activity schema and 'iati-organisations' for the organisation schema.
 
     Warning:
         The private attribute allowing access to the base Schema Tree is likely to change in determining a good way of accessing the contained schema content.
 
     Todo:
-        Determine a good API for accessing the XMLSchema that the iati.core.Schema represents.
+        Determine a good API for accessing the XMLSchema that the iati.core.ActivitySchema represents.
 
         Determine how to distinguish and handle the different types of Schema - activity, organisation, codelist, other.
 
     """
+    root_element_name = ''
 
     def __init__(self, name=None):
         """Initialise a Schema.
@@ -172,3 +174,13 @@ class Schema(object):
         etree.strip_elements(tree.getroot(), schema_xpath)
 
         return tree
+
+
+class ActivitySchema(Schema):
+    root_element_name = 'iati-activities'
+    pass
+
+
+class OrganisationSchema(Schema):
+    root_element_name = 'iati-organisations'
+    pass

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -48,7 +48,7 @@ class TestDatasets(object):
         with pytest.raises(ValueError) as excinfo:
             iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
 
-        assert 'The string provided to create a Dataset from is not valid XML.' == str(excinfo.value)
+        assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
     @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_dataset_number_not_xml(self, not_xml):
@@ -94,7 +94,7 @@ class TestDatasets(object):
         with pytest.raises(ValueError) as excinfo:
             data.xml_str = iati.core.tests.utilities.XML_STR_INVALID
 
-        assert 'The string provided to create a Dataset from is not valid XML.' == str(excinfo.value)
+        assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
     def test_dataset_xml_str_assignment_tree(self, dataset_initialised):
         """Test assignment to the xml_str property with an ElementTree."""
@@ -103,7 +103,7 @@ class TestDatasets(object):
         with pytest.raises(TypeError) as excinfo:
             data.xml_str = iati.core.tests.utilities.XML_TREE_VALID
 
-        assert 'If setting a dataset with an ElementTree, use the xml_tree property, not the xml_str property.' == str(excinfo.value)
+        assert str(excinfo.value) == 'If setting a dataset with an ElementTree, use the xml_tree property, not the xml_str property.'
 
     @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_dataset_xml_str_assignment_invalid_value(self, dataset_initialised, invalid_value):

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -86,12 +86,12 @@ class TestDefault(object):
         for _, schema in schemas.items():
             assert isinstance(schema, (iati.core.ActivitySchema, iati.core.OrganisationSchema))
 
-    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type([], False))
     def test_default_schema(self, invalid_name):
         """Check that an Error is raised when attempting to load a Schema name that does not exist.
 
         Type 'str' is excluded since a valid IATI activity name is contained within the fuzzed data.
 
         """
-        with pytest.raises((ValueError, TypeError)) as excinfo:
+        with pytest.raises((ValueError, TypeError)):
             iati.core.default.schema(invalid_name)

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -47,20 +47,44 @@ class TestDefault(object):
         for _, codelist in codelists.items():
             assert isinstance(codelist, iati.core.Codelist)
 
+    def test_default_activity_schemas(self):
+        """Check that the default ActivitySchemas are correct.
+
+        Todo:
+            Check internal values beyond the schemas being the correct type.
+        """
+        schemas = iati.core.default.activity_schemas()
+
+        assert isinstance(schemas, dict)
+        assert len(schemas) == 1
+        for _, schema in schemas.items():
+            assert isinstance(schema, iati.core.ActivitySchema)
+
+    def test_default_organisation_schemas(self):
+        """Check that the default ActivitySchemas are correct.
+
+        Todo:
+            Check internal values beyond the schemas being the correct type.
+        """
+        schemas = iati.core.default.organisation_schemas()
+
+        assert isinstance(schemas, dict)
+        assert len(schemas) == 1
+        for _, schema in schemas.items():
+            assert isinstance(schema, iati.core.OrganisationSchema)
+
     def test_default_schemas(self):
         """Check that the default Schemas are correct.
 
         Todo:
             Check internal values beyond the schemas being the correct type.
-
-            Check for the correct number of Schemas.
         """
         schemas = iati.core.default.schemas()
 
         assert isinstance(schemas, dict)
         assert len(schemas) == 2
         for _, schema in schemas.items():
-            assert isinstance(schema, iati.core.ActivitySchema) or isinstance(schema, iati.core.OrganisationSchema)
+            assert isinstance(schema, (iati.core.ActivitySchema, iati.core.OrganisationSchema))
 
     @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_default_schema(self, invalid_name):

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -61,3 +61,16 @@ class TestDefault(object):
         assert len(schemas) == 1
         for _, schema in schemas.items():
             assert isinstance(schema, iati.core.Schema)
+
+    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str', 'none', 'view', 'set', 'mapping', 'list', 'bytearray'], False))
+    def test_default_schema(self, invalid_name):
+        """Check that an Error is raised when attempting to load a Schema name that does not exist.
+
+        Todo:
+            Check for type errors when the type is incorrect.
+
+        """
+        with pytest.raises(ValueError) as excinfo:
+            iati.core.default.schema(invalid_name)
+
+        assert 'There is no default Schema in version' in str(excinfo.value)

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -62,15 +62,12 @@ class TestDefault(object):
         for _, schema in schemas.items():
             assert isinstance(schema, iati.core.ActivitySchema) or isinstance(schema, iati.core.OrganisationSchema)
 
-    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str', 'none', 'view', 'set', 'mapping', 'list', 'bytearray', 'memory', 'range'], False))
+    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_default_schema(self, invalid_name):
         """Check that an Error is raised when attempting to load a Schema name that does not exist.
 
-        Todo:
-            Check for type errors when the type is incorrect.
+        Type 'str' is excluded since a valid IATI activity name is contained within the fuzzed data.
 
         """
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises((ValueError, TypeError)) as excinfo:
             iati.core.default.schema(invalid_name)
-
-        assert 'There is no default Schema in version' in str(excinfo.value)

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -58,7 +58,7 @@ class TestDefault(object):
         schemas = iati.core.default.schemas()
 
         assert isinstance(schemas, dict)
-        assert len(schemas) == 1
+        assert len(schemas) == 2
         for _, schema in schemas.items():
             assert isinstance(schema, iati.core.Schema)
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -60,7 +60,7 @@ class TestDefault(object):
         assert isinstance(schemas, dict)
         assert len(schemas) == 2
         for _, schema in schemas.items():
-            assert isinstance(schema, iati.core.Schema)
+            assert isinstance(schema, iati.core.ActivitySchema) or isinstance(schema, iati.core.OrganisationSchema)
 
     @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str', 'none', 'view', 'set', 'mapping', 'list', 'bytearray', 'memory', 'range'], False))
     def test_default_schema(self, invalid_name):

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -88,10 +88,6 @@ class TestDefault(object):
 
     @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type([], False))
     def test_default_schema(self, invalid_name):
-        """Check that an Error is raised when attempting to load a Schema name that does not exist.
-
-        Type 'str' is excluded since a valid IATI activity name is contained within the fuzzed data.
-
-        """
+        """Check that an Error is raised when attempting to load a Schema name that does not exist."""
         with pytest.raises((ValueError, TypeError)):
             iati.core.default.schema(invalid_name)

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -1,6 +1,7 @@
 """A module containing tests for the library representation of default values."""
 import pytest
 import iati.core.codelists
+import iati.core.constants
 import iati.core.default
 import iati.core.schemas
 
@@ -79,11 +80,13 @@ class TestDefault(object):
         Todo:
             Check internal values beyond the schemas being the correct type.
         """
+        version = iati.core.constants.STANDARD_VERSION_LATEST
         schemas = iati.core.default.schemas()
 
         assert isinstance(schemas, dict)
-        assert len(schemas) == 2
-        for _, schema in schemas.items():
+        assert isinstance(schemas[version], dict)
+        assert len(schemas[version]) == 2
+        for schema in schemas[version].values():
             assert isinstance(schema, (iati.core.ActivitySchema, iati.core.OrganisationSchema))
 
     @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type([], False))

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -62,7 +62,7 @@ class TestDefault(object):
         for _, schema in schemas.items():
             assert isinstance(schema, iati.core.Schema)
 
-    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str', 'none', 'view', 'set', 'mapping', 'list', 'bytearray'], False))
+    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str', 'none', 'view', 'set', 'mapping', 'list', 'bytearray', 'memory', 'range'], False))
     def test_default_schema(self, invalid_name):
         """Check that an Error is raised when attempting to load a Schema name that does not exist.
 

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -55,14 +55,14 @@ class TestResources(object):
             Add other tests relating to specific versions of the Standard.
 
         """
-        paths = iati.core.resources.find_all_codelist_paths()
+        paths = iati.core.resources.get_all_codelist_paths()
 
         assert len(paths) == 62
         for path in paths:
             assert path[-4:] == iati.core.resources.FILE_CODELIST_EXTENSION
             assert iati.core.resources.PATH_CODELISTS in path
 
-    def test_find_all_activity_schema_paths(self):
+    def test_get_all_activity_schema_paths(self):
         """Check that all activity schema paths are found.
 
         Todo:
@@ -71,11 +71,11 @@ class TestResources(object):
             Handle all paths to schemas being found correctly.
 
         """
-        activity_paths = iati.core.resources.find_all_activity_schema_paths()
+        activity_paths = iati.core.resources.get_all_activity_schema_paths()
 
         assert len(activity_paths) == 1
 
-    def test_find_all_organisation_schema_paths(self):
+    def test_get_all_organisation_schema_paths(self):
         """Check that all organisation schema paths are found.
 
         Todo:
@@ -84,7 +84,7 @@ class TestResources(object):
             Handle all paths to schemas being found correctly.
 
         """
-        organisation_paths = iati.core.resources.find_all_organisation_schema_paths()
+        organisation_paths = iati.core.resources.get_all_organisation_schema_paths()
 
         assert len(organisation_paths) == 1
 
@@ -97,17 +97,17 @@ class TestResources(object):
             Handle all paths to schemas being found correctly.
 
         """
-        paths = iati.core.resources.find_all_schema_paths()
+        paths = iati.core.resources.get_all_schema_paths()
 
         assert len(paths) == 2
 
     @pytest.mark.parametrize('get_schema_path_function', [
-        iati.core.resources.find_all_schema_paths,
-        iati.core.resources.find_all_activity_schema_paths,
-        iati.core.resources.find_all_organisation_schema_paths
+        iati.core.resources.get_all_schema_paths,
+        iati.core.resources.get_all_activity_schema_paths,
+        iati.core.resources.get_all_organisation_schema_paths
         ])
     def test_find_schema_paths_file_extension(self, get_schema_path_function):
-        """Check that the correct file extension is present within file paths returned by find_all_*schema_paths functions."""
+        """Check that the correct file extension is present within file paths returned by get_all_*schema_paths functions."""
         paths = get_schema_path_function()
 
         for path in paths:

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -62,6 +62,40 @@ class TestResources(object):
             assert path[-4:] == iati.core.resources.FILE_CODELIST_EXTENSION
             assert iati.core.resources.PATH_CODELISTS in path
 
+    def test_find_all_activity_schema_paths(self):
+        """Check that all activity schema paths are found.
+
+        Todo:
+            Add other tests relating to specific versions of the Standard.
+
+            Handle all paths to schemas being found correctly.
+
+            Refactor to remove duplicate code in test_find_all_activity_schema_paths, test_find_all_organisation_schema_paths and test_find_schema_paths.
+
+        """
+        activity_paths = iati.core.resources.find_all_activity_schema_paths()
+
+        assert len(activity_paths) == 1
+        for path in activity_paths:
+            assert path[-4:] == iati.core.resources.FILE_SCHEMA_EXTENSION
+
+    def test_find_all_organisation_schema_paths(self):
+        """Check that all organisation schema paths are found.
+
+        Todo:
+            Add other tests relating to specific versions of the Standard.
+
+            Handle all paths to schemas being found correctly.
+
+            Refactor to remove duplicate code in test_find_all_activity_schema_paths, test_find_all_organisation_schema_paths and test_find_schema_paths.
+
+        """
+        organisation_paths = iati.core.resources.find_all_organisation_schema_paths()
+
+        assert len(organisation_paths) == 1
+        for path in organisation_paths:
+            assert path[-4:] == iati.core.resources.FILE_SCHEMA_EXTENSION
+
     def test_find_schema_paths(self):
         """Check that all schema paths are being found.
 
@@ -69,6 +103,8 @@ class TestResources(object):
             Add other tests relating to specific versions of the Standard.
 
             Handle all paths to schemas being found correctly.
+
+            Refactor to remove duplicate code in test_find_all_activity_schema_paths, test_find_all_organisation_schema_paths and test_find_schema_paths.
 
         """
         paths = iati.core.resources.find_all_schema_paths()

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -105,7 +105,7 @@ class TestResources(object):
         iati.core.resources.get_all_schema_paths,
         iati.core.resources.get_all_activity_schema_paths,
         iati.core.resources.get_all_organisation_schema_paths
-        ])
+    ])
     def test_find_schema_paths_file_extension(self, get_schema_path_function):
         """Check that the correct file extension is present within file paths returned by get_all_*schema_paths functions."""
         paths = get_schema_path_function()

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -73,7 +73,7 @@ class TestResources(object):
         """
         paths = iati.core.resources.find_all_schema_paths()
 
-        assert len(paths) == 1
+        assert len(paths) == 2
         for path in paths:
             assert path[-4:] == iati.core.resources.FILE_SCHEMA_EXTENSION
 

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -70,14 +70,10 @@ class TestResources(object):
 
             Handle all paths to schemas being found correctly.
 
-            Refactor to remove duplicate code in test_find_all_activity_schema_paths, test_find_all_organisation_schema_paths and test_find_schema_paths.
-
         """
         activity_paths = iati.core.resources.find_all_activity_schema_paths()
 
         assert len(activity_paths) == 1
-        for path in activity_paths:
-            assert path[-4:] == iati.core.resources.FILE_SCHEMA_EXTENSION
 
     def test_find_all_organisation_schema_paths(self):
         """Check that all organisation schema paths are found.
@@ -87,14 +83,10 @@ class TestResources(object):
 
             Handle all paths to schemas being found correctly.
 
-            Refactor to remove duplicate code in test_find_all_activity_schema_paths, test_find_all_organisation_schema_paths and test_find_schema_paths.
-
         """
         organisation_paths = iati.core.resources.find_all_organisation_schema_paths()
 
         assert len(organisation_paths) == 1
-        for path in organisation_paths:
-            assert path[-4:] == iati.core.resources.FILE_SCHEMA_EXTENSION
 
     def test_find_schema_paths(self):
         """Check that all schema paths are being found.
@@ -104,12 +96,20 @@ class TestResources(object):
 
             Handle all paths to schemas being found correctly.
 
-            Refactor to remove duplicate code in test_find_all_activity_schema_paths, test_find_all_organisation_schema_paths and test_find_schema_paths.
-
         """
         paths = iati.core.resources.find_all_schema_paths()
 
         assert len(paths) == 2
+
+    @pytest.mark.parametrize('get_schema_path_function', [
+        iati.core.resources.find_all_schema_paths,
+        iati.core.resources.find_all_activity_schema_paths,
+        iati.core.resources.find_all_organisation_schema_paths
+        ])
+    def test_find_schema_paths_file_extension(self, get_schema_path_function):
+        """Check that the correct file extension is present within file paths returned by find_all_*schema_paths functions."""
+        paths = get_schema_path_function()
+
         for path in paths:
             assert path[-4:] == iati.core.resources.FILE_SCHEMA_EXTENSION
 

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -39,8 +39,8 @@ class TestSchemas(object):
         iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID,
         iati.core.tests.utilities.SCHEMA_ORGANISATION_NAME_VALID
     ])
-    def schemas_initialised(self, request):
-        """Create both an ActivitySchema and OrganisaionSchema class.
+    def schema_initialised(self, request):
+        """Create and return a single ActivitySchema or OrganisaionSchema object.
         For use where both ActivitySchema and OrganisaionSchema must produce the same result.
 
         Returns:
@@ -61,9 +61,9 @@ class TestSchemas(object):
 
         assert schema.root_element_name == expected_value
 
-    def test_schema_define_from_xsd(self, schemas_initialised):
+    def test_schema_define_from_xsd(self, schema_initialised):
         """Check that a Schema can be generated from an XSD definition."""
-        schema = schemas_initialised
+        schema = schema_initialised
 
         assert isinstance(schema.codelists, set)
         assert len(schema.codelists) == 0
@@ -173,20 +173,20 @@ class TestSchemas(object):
         assert isinstance(tree.getroot().find(included_xpath), etree._Element)
         assert iati.core.utilities.convert_tree_to_schema(tree)
 
-    def test_schema_codelists_add(self, schemas_initialised):
+    def test_schema_codelists_add(self, schema_initialised):
         """Check that it is possible to add Codelists to the Schema."""
         codelist_name = "a test Codelist name"
-        schema = schemas_initialised
+        schema = schema_initialised
         codelist = iati.core.Codelist(codelist_name)
 
         schema.codelists.add(codelist)
 
         assert len(schema.codelists) == 1
 
-    def test_schema_codelists_add_twice(self, schemas_initialised):
+    def test_schema_codelists_add_twice(self, schema_initialised):
         """Check that it is not possible to add the same Codelist to a Schema multiple times."""
         codelist_name = "a test Codelist name"
-        schema = schemas_initialised
+        schema = schema_initialised
         codelist = iati.core.Codelist(codelist_name)
 
         schema.codelists.add(codelist)
@@ -194,10 +194,10 @@ class TestSchemas(object):
 
         assert len(schema.codelists) == 1
 
-    def test_schema_codelists_add_duplicate(self, schemas_initialised):
+    def test_schema_codelists_add_duplicate(self, schema_initialised):
         """Check that it is not possible to add multiple functionally identical Codelists to a Schema."""
         codelist_name = "a test Codelist name"
-        schema = schemas_initialised
+        schema = schema_initialised
         codelist = iati.core.Codelist(codelist_name)
         codelist2 = iati.core.Codelist(codelist_name)
 
@@ -206,10 +206,10 @@ class TestSchemas(object):
 
         assert len(schema.codelists) == 1
 
-    def test_schema_rulesets_add(self, schemas_initialised):
+    def test_schema_rulesets_add(self, schema_initialised):
         """Check that it is possible to add Rulesets to the Schema."""
         codelist_name = "a test Codelist name"
-        schema = schemas_initialised
+        schema = schema_initialised
         ruleset = iati.core.Ruleset()
 
         schema.rulesets.add(ruleset)
@@ -217,11 +217,11 @@ class TestSchemas(object):
         assert len(schema.rulesets) == 1
 
     @pytest.mark.skip(reason='Not implemented')
-    def test_schema_rulesets_add_twice(self, schemas_initialised):
+    def test_schema_rulesets_add_twice(self, schema_initialised):
         """Check that it is not possible to add the sameRulesets to a Schema multiple times."""
         raise NotImplementedError
 
     @pytest.mark.skip(reason='Not implemented')
-    def test_schema_rulesets_add_duplicate(self, schemas_initialised):
+    def test_schema_rulesets_add_duplicate(self, schema_initialised):
         """Check that it is not possible to add multiple functionally identical Rulesets to a Schema."""
         raise NotImplementedError

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -15,16 +15,16 @@ class TestSchemas(object):
         """Create a very basic Schema.
 
         Returns:
-            iati.core.Schema: A Schema that has been initialised with basic values.
+            iati.core.ActivitySchema: An ActivitySchema that has been initialised with basic values.
 
         """
         schema_name = iati.core.tests.utilities.SCHEMA_NAME_VALID
 
-        return iati.core.Schema(name=schema_name)
+        return iati.core.ActivitySchema(name=schema_name)
 
     def test_schema_default_attributes(self):
         """Check a Schema's default attributes are correct."""
-        schema = iati.core.Schema()
+        schema = iati.core.ActivitySchema()
 
         assert schema.name is None
 
@@ -37,7 +37,7 @@ class TestSchemas(object):
 
         """
         with pytest.raises(TypeError) as excinfo:
-            iati.core.Schema(invalid_name)
+            iati.core.ActivitySchema(invalid_name)
 
         assert 'The name of the Schema is an invalid type. Must be a string, though was a' in str(excinfo.value)
 

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -36,7 +36,7 @@ class TestSchemas(object):
         schema = iati.core.default.schema(schema_type)
 
         assert schema.root_element_name == expected_root_element_name
-        assert expected_root_element_name in schema.source_path
+        assert expected_root_element_name in schema._source_path
 
     def test_schema_define_from_xsd(self, schema_initialised):
         """Check that a Schema can be generated from an XSD definition."""

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -8,30 +8,6 @@ import iati.core.schemas
 import iati.core.tests.utilities
 
 
-def default_activity_schema():
-    """Create a very basic acivity schema.
-
-    Returns:
-        iati.core.ActivitySchema: An ActivitySchema that has been initialised based on the default IATI Activity Schema.
-
-    """
-    schema_name = iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID
-
-    return iati.core.default.schema(schema_name)
-
-
-def default_organisation_schema():
-    """Create a very basic organisaion schema.
-
-    Returns:
-        iati.core.OrganisaionSchema: An OrganisaionSchema that has been initialised based on the default IATI Organisaion Schema.
-
-    """
-    schema_name = iati.core.tests.utilities.SCHEMA_ORGANISATION_NAME_VALID
-
-    return iati.core.default.schema(schema_name)
-
-
 class TestSchemas(object):
     """A container for tests relating to Schemas."""
 
@@ -52,12 +28,12 @@ class TestSchemas(object):
         return iati.core.default.schema(schema_name)
 
     @pytest.mark.parametrize("schema_type, expected_value", [
-        (default_activity_schema, 'iati-activities'),
-        (default_organisation_schema, 'iati-organisations')
+        ('iati-activities-schema', 'iati-activities'),
+        ('iati-organisations-schema', 'iati-organisations')
     ])
     def test_schema_default_attributes(self, schema_type, expected_value):
         """Check a Schema's default attributes are correct."""
-        schema = schema_type()
+        schema = iati.core.default.schema(schema_type)
 
         assert schema.root_element_name == expected_value
 
@@ -69,8 +45,8 @@ class TestSchemas(object):
         assert len(schema_initialised.rulesets) == 0
 
     @pytest.mark.parametrize("schema_type, expected_local_element", [
-        (default_activity_schema, 'iati-activities'),
-        (default_organisation_schema, 'iati-organisations')
+        ('iati-activities-schema', 'iati-activities'),
+        ('iati-organisations-schema', 'iati-organisations')
     ])
     def test_schema_unmodified_includes(self, schema_type, expected_local_element):
         """Check that local elements can be accessed, but imported elements within unmodified Schema includes cannot be accessed.
@@ -82,7 +58,7 @@ class TestSchemas(object):
             Simplify asserts.
 
         """
-        schema = schema_type()
+        schema = iati.core.default.schema(schema_type)
         local_element = expected_local_element
         included_element = 'reporting-org'
 
@@ -95,8 +71,8 @@ class TestSchemas(object):
         assert schema._schema_base_tree.getroot().find(included_xpath) is None
 
     @pytest.mark.parametrize("schema_type, expected_local_element", [
-        (default_activity_schema, 'iati-activities'),
-        (default_organisation_schema, 'iati-organisations')
+        ('iati-activities-schema', 'iati-activities'),
+        ('iati-organisations-schema', 'iati-organisations')
     ])
     def test_schema_modified_includes(self, schema_type, expected_local_element):
         """Check that elements within unflattened modified Schema includes cannot be accessed.
@@ -111,7 +87,7 @@ class TestSchemas(object):
             Consider consolidating variables shared between multiple tests.
 
         """
-        schema = schema_type()
+        schema = iati.core.default.schema(schema_type)
         local_element = expected_local_element
         included_element = 'reporting-org'
 

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -19,6 +19,7 @@ def default_activity_schema():
 
     return iati.core.default.schema(schema_name)
 
+
 def default_organisation_schema():
     """Create a very basic organisaion schema.
 

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -63,12 +63,10 @@ class TestSchemas(object):
 
     def test_schema_define_from_xsd(self, schema_initialised):
         """Check that a Schema can be generated from an XSD definition."""
-        schema = schema_initialised
-
-        assert isinstance(schema.codelists, set)
-        assert len(schema.codelists) == 0
-        assert isinstance(schema.rulesets, set)
-        assert len(schema.rulesets) == 0
+        assert isinstance(schema_initialised.codelists, set)
+        assert len(schema_initialised.codelists) == 0
+        assert isinstance(schema_initialised.rulesets, set)
+        assert len(schema_initialised.rulesets) == 0
 
     @pytest.mark.parametrize("schema_type, expected_local_element", [
         (default_activity_schema, 'iati-activities'),
@@ -176,45 +174,41 @@ class TestSchemas(object):
     def test_schema_codelists_add(self, schema_initialised):
         """Check that it is possible to add Codelists to the Schema."""
         codelist_name = "a test Codelist name"
-        schema = schema_initialised
         codelist = iati.core.Codelist(codelist_name)
 
-        schema.codelists.add(codelist)
+        schema_initialised.codelists.add(codelist)
 
-        assert len(schema.codelists) == 1
+        assert len(schema_initialised.codelists) == 1
 
     def test_schema_codelists_add_twice(self, schema_initialised):
         """Check that it is not possible to add the same Codelist to a Schema multiple times."""
         codelist_name = "a test Codelist name"
-        schema = schema_initialised
         codelist = iati.core.Codelist(codelist_name)
 
-        schema.codelists.add(codelist)
-        schema.codelists.add(codelist)
+        schema_initialised.codelists.add(codelist)
+        schema_initialised.codelists.add(codelist)
 
-        assert len(schema.codelists) == 1
+        assert len(schema_initialised.codelists) == 1
 
     def test_schema_codelists_add_duplicate(self, schema_initialised):
         """Check that it is not possible to add multiple functionally identical Codelists to a Schema."""
         codelist_name = "a test Codelist name"
-        schema = schema_initialised
         codelist = iati.core.Codelist(codelist_name)
         codelist2 = iati.core.Codelist(codelist_name)
 
-        schema.codelists.add(codelist)
-        schema.codelists.add(codelist2)
+        schema_initialised.codelists.add(codelist)
+        schema_initialised.codelists.add(codelist2)
 
-        assert len(schema.codelists) == 1
+        assert len(schema_initialised.codelists) == 1
 
     def test_schema_rulesets_add(self, schema_initialised):
         """Check that it is possible to add Rulesets to the Schema."""
         codelist_name = "a test Codelist name"
-        schema = schema_initialised
         ruleset = iati.core.Ruleset()
 
-        schema.rulesets.add(ruleset)
+        schema_initialised.rulesets.add(ruleset)
 
-        assert len(schema.rulesets) == 1
+        assert len(schema_initialised.rulesets) == 1
 
     @pytest.mark.skip(reason='Not implemented')
     def test_schema_rulesets_add_twice(self, schema_initialised):

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -2,6 +2,7 @@
 from lxml import etree
 import pytest
 import iati.core.codelists
+import iati.core.default
 import iati.core.exceptions
 import iati.core.schemas
 import iati.core.tests.utilities
@@ -20,32 +21,18 @@ class TestSchemas(object):
         """
         schema_name = iati.core.tests.utilities.SCHEMA_NAME_VALID
 
-        return iati.core.ActivitySchema(name=schema_name)
+        return iati.core.default.schema(schema_name)
 
-    def test_schema_default_attributes(self):
+    def test_schema_default_attributes(self, schema_initialised):
         """Check a Schema's default attributes are correct."""
-        schema = iati.core.ActivitySchema()
+        schema = schema_initialised
 
-        assert schema.name is None
-
-    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type(['str', 'none'], False))
-    def test_schema_name_instance(self, invalid_name):
-        """Check that an Error is raised when attempting to load a Schema that does not exist.
-
-        Todo:
-            Check for type errors when the type is incorrect.
-
-        """
-        with pytest.raises(TypeError) as excinfo:
-            iati.core.ActivitySchema(invalid_name)
-
-        assert 'The name of the Schema is an invalid type. Must be a string, though was a' in str(excinfo.value)
+        assert schema.root_element_name == 'iati-activities'
 
     def test_schema_define_from_xsd(self, schema_initialised):
         """Check that a Schema can be generated from an XSD definition."""
         schema = schema_initialised
 
-        assert schema.name == iati.core.tests.utilities.SCHEMA_NAME_VALID
         assert isinstance(schema.codelists, set)
         assert len(schema.codelists) == 0
 
@@ -119,8 +106,12 @@ class TestSchemas(object):
 
             Assert that the flattened XML is a valid Schema.
 
+            Test that this works with subclasses of iati.core.Schema: iati.core.ActivitySchema and iati.core.OrganisationSchema
+
         """
-        schema = schema_initialised
+        schema_name = iati.core.tests.utilities.SCHEMA_NAME_VALID
+        schema_path = iati.core.resources.get_schema_path(schema_name)
+        schema = iati.core.Schema(schema_path)
         local_element = 'iati-activities'
         included_element = 'reporting-org'
 

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -206,10 +206,10 @@ class TestSchemas(object):
 
         assert len(schema.codelists) == 1
 
-    def test_schema_rulesets_add(self, schema_initialised):
+    def test_schema_rulesets_add(self, schemas_initialised):
         """Check that it is possible to add Rulesets to the Schema."""
         codelist_name = "a test Codelist name"
-        schema = schema_initialised
+        schema = schemas_initialised
         ruleset = iati.core.Ruleset()
 
         schema.rulesets.add(ruleset)
@@ -217,11 +217,11 @@ class TestSchemas(object):
         assert len(schema.rulesets) == 1
 
     @pytest.mark.skip(reason='Not implemented')
-    def test_schema_rulesets_add_twice(self, schema_initialised):
+    def test_schema_rulesets_add_twice(self, schemas_initialised):
         """Check that it is not possible to add the sameRulesets to a Schema multiple times."""
         raise NotImplementedError
 
     @pytest.mark.skip(reason='Not implemented')
-    def test_schema_rulesets_add_duplicate(self, schema_initialised):
+    def test_schema_rulesets_add_duplicate(self, schemas_initialised):
         """Check that it is not possible to add multiple functionally identical Rulesets to a Schema."""
         raise NotImplementedError

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -27,15 +27,16 @@ class TestSchemas(object):
 
         return iati.core.default.schema(schema_name)
 
-    @pytest.mark.parametrize("schema_type, expected_value", [
+    @pytest.mark.parametrize("schema_type, expected_root_element_name", [
         ('iati-activities-schema', 'iati-activities'),
         ('iati-organisations-schema', 'iati-organisations')
     ])
-    def test_schema_default_attributes(self, schema_type, expected_value):
+    def test_schema_default_attributes(self, schema_type, expected_root_element_name):
         """Check a Schema's default attributes are correct."""
         schema = iati.core.default.schema(schema_type)
 
-        assert schema.root_element_name == expected_value
+        assert schema.root_element_name == expected_root_element_name
+        assert expected_root_element_name in schema.source_path
 
     def test_schema_define_from_xsd(self, schema_initialised):
         """Check that a Schema can be generated from an XSD definition."""

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -152,11 +152,11 @@ class TestSchemas(object):
 
             Assert that the flattened XML is a valid Schema.
 
-            Test that this works with subclasses of iati.core.Schema: iati.core.ActivitySchema and iati.core.OrganisationSchema
+            Test that this works with subclasses of iati.core.schemas.Schema: iati.core.ActivitySchema and iati.core.OrganisationSchema
 
         """
         schema_path = iati.core.resources.get_schema_path(schema_name)
-        schema = iati.core.Schema(schema_path)
+        schema = iati.core.schemas.Schema(schema_path)
         local_element = expected_local_element
         included_element = 'reporting-org'
 

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -35,7 +35,7 @@ class TestSchemas(object):
         """Check a Schema's default attributes are correct."""
         schema = iati.core.default.schema(schema_type)
 
-        assert schema.root_element_name == expected_root_element_name
+        assert schema.ROOT_ELEMENT_NAME == expected_root_element_name
         assert expected_root_element_name in schema._source_path
 
     def test_schema_define_from_xsd(self, schema_initialised):

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -19,7 +19,7 @@ class TestSchemas(object):
             iati.core.ActivitySchema: An ActivitySchema that has been initialised with basic values.
 
         """
-        schema_name = iati.core.tests.utilities.SCHEMA_NAME_VALID
+        schema_name = iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID
 
         return iati.core.default.schema(schema_name)
 
@@ -109,7 +109,7 @@ class TestSchemas(object):
             Test that this works with subclasses of iati.core.Schema: iati.core.ActivitySchema and iati.core.OrganisationSchema
 
         """
-        schema_name = iati.core.tests.utilities.SCHEMA_NAME_VALID
+        schema_name = iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID
         schema_path = iati.core.resources.get_schema_path(schema_name)
         schema = iati.core.Schema(schema_path)
         local_element = 'iati-activities'

--- a/iati/core/tests/test_utilities.py
+++ b/iati/core/tests/test_utilities.py
@@ -12,7 +12,7 @@ class TestUtilities(object):
     @pytest.fixture
     def schema_base_tree(self):
         """Return schema_base_tree."""
-        activity_schema_path = iati.core.resources.get_schema_path(iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        activity_schema_path = iati.core.resources.get_schema_path(iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         return iati.core.ActivitySchema(activity_schema_path)._schema_base_tree
 
     def test_add_namespace_schema_new(self, schema_base_tree):

--- a/iati/core/tests/test_utilities.py
+++ b/iati/core/tests/test_utilities.py
@@ -12,7 +12,7 @@ class TestUtilities(object):
     @pytest.fixture
     def schema_base_tree(self):
         """Return schema_base_tree."""
-        return iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)._schema_base_tree
+        return iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)._schema_base_tree
 
     def test_add_namespace_schema_new(self, schema_base_tree):
         """Check that an additional namespace can be added to a Schema.

--- a/iati/core/tests/test_utilities.py
+++ b/iati/core/tests/test_utilities.py
@@ -12,7 +12,9 @@ class TestUtilities(object):
     @pytest.fixture
     def schema_base_tree(self):
         """Return schema_base_tree."""
-        activity_schema_path = iati.core.resources.get_schema_path(iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
+        activity_schema_path = iati.core.resources.get_schema_path(
+            iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID
+        )
         return iati.core.ActivitySchema(activity_schema_path)._schema_base_tree
 
     def test_add_namespace_schema_new(self, schema_base_tree):

--- a/iati/core/tests/test_utilities.py
+++ b/iati/core/tests/test_utilities.py
@@ -12,7 +12,8 @@ class TestUtilities(object):
     @pytest.fixture
     def schema_base_tree(self):
         """Return schema_base_tree."""
-        return iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)._schema_base_tree
+        activity_schema_path = iati.core.resources.get_schema_path(iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        return iati.core.ActivitySchema(activity_schema_path)._schema_base_tree
 
     def test_add_namespace_schema_new(self, schema_base_tree):
         """Check that an additional namespace can be added to a Schema.

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -19,7 +19,7 @@ import decimal
 from lxml import etree
 import iati.core.resources
 
-SCHEMA_NAME_VALID = 'iati-activities-schema'
+SCHEMA_ACTIVITY_NAME_VALID = 'iati-activities-schema'
 """A string containing a valid Schema name."""
 
 XML_STR_VALID_NOT_IATI = '<parent><child attribute="value" /></parent>'
@@ -84,7 +84,7 @@ TYPE_TEST_DATA = {
     'other': [NotImplemented],
     'range': [range(3, 4)],
     'set': [set(range(20)), set(['hello', 23]), frozenset(range(20)), frozenset(['hello', 23])],
-    'str': [SCHEMA_NAME_VALID, XML_STR_VALID_NOT_IATI, XML_STR_INVALID, b'\x80abc', b'\x80abc', '\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394'],
+    'str': [SCHEMA_ACTIVITY_NAME_VALID, XML_STR_VALID_NOT_IATI, XML_STR_INVALID, b'\x80abc', b'\x80abc', '\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394'],
     'tuple': [(), (1, 2)],
     'type': [type(1), type('string')],
     'unicode': [],  # counts as a string, so moved there

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -92,7 +92,11 @@ TYPE_TEST_DATA = {
     'unicode': [],  # counts as a string, so moved there
     'view': [{}.keys(), dict(zip(['one', 'two', 'three'], [1, 2, 3])).items(), dict(one=1, two=2, three=3).values()]
 }
-"""Generic test data of various Python builtin types."""
+"""Generic test data of various Python builtin types.
+
+Todo:
+    Remove SCHEMA_ACTIVITY_NAME_VALID from TYPE_TEST_DATA['str'], so that it can be better used to fuzz a wider range of functions without accidentally being valid.
+"""
 
 
 def find_parameter_by_type(types, type_as_specified=True):

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -86,7 +86,7 @@ TYPE_TEST_DATA = {
     'other': [NotImplemented],
     'range': [range(3, 4)],
     'set': [set(range(20)), set(['hello', 23]), frozenset(range(20)), frozenset(['hello', 23])],
-    'str': [SCHEMA_ACTIVITY_NAME_VALID, XML_STR_VALID_NOT_IATI, XML_STR_INVALID, b'\x80abc', b'\x80abc', '\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394'],
+    'str': [b'\x80abc', b'\x80abc', '\N{GREEK CAPITAL LETTER DELTA}', '\u0394', '\U00000394'],
     'tuple': [(), (1, 2)],
     'type': [type(1), type('string')],
     'unicode': [],  # counts as a string, so moved there

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -20,7 +20,9 @@ from lxml import etree
 import iati.core.resources
 
 SCHEMA_ACTIVITY_NAME_VALID = 'iati-activities-schema'
-"""A string containing a valid Schema name."""
+"""A string containing a valid IATI Activity Schema name."""
+SCHEMA_ORGANISATION_NAME_VALID = 'iati-organisations-schema'
+"""A string containing a valid IATI Organisaion Schema name."""
 
 XML_STR_VALID_NOT_IATI = '<parent><child attribute="value" /></parent>'
 """A string containing valid XML that is not valid against the IATI schema."""

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -92,11 +92,7 @@ TYPE_TEST_DATA = {
     'unicode': [],  # counts as a string, so moved there
     'view': [{}.keys(), dict(zip(['one', 'two', 'three'], [1, 2, 3])).items(), dict(one=1, two=2, three=3).values()]
 }
-"""Generic test data of various Python builtin types.
-
-Todo:
-    Remove SCHEMA_ACTIVITY_NAME_VALID from TYPE_TEST_DATA['str'], so that it can be better used to fuzz a wider range of functions without accidentally being valid.
-"""
+"""Generic test data of various Python builtin types."""
 
 
 def find_parameter_by_type(types, type_as_specified=True):

--- a/iati/core/utilities.py
+++ b/iati/core/utilities.py
@@ -83,7 +83,7 @@ def convert_tree_to_schema(tree):
     Warning:
         Should raise exceptions when there are errors during execution.
 
-        Needs to better distinguish between an `etree.XMLSchema` and an `iati.core.Schema`.
+        Needs to better distinguish between an `etree.XMLSchema`, an `iati.core.Schema`, an `iati.core.ActivitySchema` and an `iati.core.OrganisationSchema`.
 
         Does not fully hide the lxml internal workings.
 

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -14,35 +14,35 @@ class TestValidate(object):
     def test_basic_validation_valid(self):
         """Perform a super simple data validation against a valid activity Dataset."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid(self):
         """Perform a super simple data validation against an invalid activity Dataset."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element(self):
         """Perform a super simple data validation against an activity Dataset that is invalid due to a missing required element."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element_from_common(self):
         """Perform a super simple data validation against an activity Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_valid(self):
         """Perform data validation against valid IATI activity XML that has valid Codelist values."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
         schema.codelists.add(codelist)
@@ -52,7 +52,7 @@ class TestValidate(object):
     def test_basic_validation_codelist_invalid(self):
         """Perform data validation against valid IATI activity XML that has invalid Codelist values."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
         schema.codelists.add(codelist)
@@ -62,7 +62,7 @@ class TestValidate(object):
     def test_basic_validation_codelist_valid_from_common(self):
         """Perform data validation against valid IATI activity XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
         schema.codelists.add(codelist)
@@ -72,7 +72,7 @@ class TestValidate(object):
     def test_basic_validation_codelist_invalid_from_common(self):
         """Perform data validation against valid IATI activity XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
         schema.codelists.add(codelist)
@@ -82,7 +82,7 @@ class TestValidate(object):
     def test_validation_codelist_vocab_default_implicit(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been implicitly set."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -96,7 +96,7 @@ class TestValidate(object):
     def test_validation_codelist_vocab_default_implicit_invalid_code(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been implicitly set. The code is invalid."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -110,7 +110,7 @@ class TestValidate(object):
     def test_validation_codelist_vocab_default_explicit(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been explicitly set as the default value."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -124,7 +124,7 @@ class TestValidate(object):
     def test_validation_codelist_vocab_non_default(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_NON_DEFAULT)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -138,7 +138,7 @@ class TestValidate(object):
     def test_validation_codelist_vocab_user_defined(self):
         """Perform data validation against valid IATI activity XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -152,7 +152,7 @@ class TestValidate(object):
     def test_validation_codelist_vocab_user_defined_with_uri_readable(self):
         """Perform data validation against valid IATI activity XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -170,7 +170,7 @@ class TestValidate(object):
             Check that this is a legitimate check to be performed, given the contents and guidance given in the Standard.
         """
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -188,7 +188,7 @@ class TestValidate(object):
             Remove xfail and work on functionality to fully fetch and parse user-defined codelists after higher priority functionality is finished.
         """
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE)
-        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -12,37 +12,37 @@ class TestValidate(object):
     """A container for tests relating to validation."""
 
     def test_basic_validation_valid(self):
-        """Perform a super simple data validation against a valid Dataset."""
+        """Perform a super simple data validation against a valid activity Dataset."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid(self):
-        """Perform a super simple data validation against an invalid Dataset."""
+        """Perform a super simple data validation against an invalid activity Dataset."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element(self):
-        """Perform a super simple data validation against a Dataset that is invalid due to a missing required element."""
+        """Perform a super simple data validation against an activity Dataset that is invalid due to a missing required element."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element_from_common(self):
-        """Perform a super simple data validation against a Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
+        """Perform a super simple data validation against an activity Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_valid(self):
-        """Perform data validation against valid IATI XML that has valid Codelist values."""
+        """Perform data validation against valid IATI activity XML that has valid Codelist values."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
         schema.codelists.add(codelist)
@@ -50,9 +50,9 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_invalid(self):
-        """Perform data validation against valid IATI XML that has invalid Codelist values."""
+        """Perform data validation against valid IATI activity XML that has invalid Codelist values."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
         schema.codelists.add(codelist)
@@ -60,9 +60,9 @@ class TestValidate(object):
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_valid_from_common(self):
-        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd."""
+        """Perform data validation against valid IATI activity XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
         schema.codelists.add(codelist)
@@ -70,9 +70,9 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_invalid_from_common(self):
-        """Perform data validation against valid IATI XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd."""
+        """Perform data validation against valid IATI activity XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
         schema.codelists.add(codelist)
@@ -80,9 +80,9 @@ class TestValidate(object):
         assert not iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_default_implicit(self):
-        """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set."""
+        """Perform data validation against valid IATI activity XML with a vocabulary that has been implicitly set."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -94,9 +94,9 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_default_implicit_invalid_code(self):
-        """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set. The code is invalid."""
+        """Perform data validation against valid IATI activity XML with a vocabulary that has been implicitly set. The code is invalid."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -108,9 +108,9 @@ class TestValidate(object):
         assert not iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_default_explicit(self):
-        """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as the default value."""
+        """Perform data validation against valid IATI activity XML with a vocabulary that has been explicitly set as the default value."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -122,9 +122,9 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_non_default(self):
-        """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
+        """Perform data validation against valid IATI activity XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_NON_DEFAULT)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -136,9 +136,9 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_user_defined(self):
-        """Perform data validation against valid IATI XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
+        """Perform data validation against valid IATI activity XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -150,9 +150,9 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_user_defined_with_uri_readable(self):
-        """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
+        """Perform data validation against valid IATI activity XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -164,13 +164,13 @@ class TestValidate(object):
         assert iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_user_defined_with_uri_readable_bad_code(self):
-        """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is not in the list.
+        """Perform data validation against valid IATI activity XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is not in the list.
 
         Todo:
             Check that this is a legitimate check to be performed, given the contents and guidance given in the Standard.
         """
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']
@@ -182,13 +182,13 @@ class TestValidate(object):
         assert not iati.validate.is_valid(data, schema)
 
     def test_validation_codelist_vocab_user_defined_with_uri_unreadable(self):
-        """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a non-machine-readable codelist. As such, the @code cannot be checked. The @code is valid.
+        """Perform data validation against valid IATI activity XML with a user-defined vocabulary. A URI is defined, and points to a non-machine-readable codelist. As such, the @code cannot be checked. The @code is valid.
 
         Todo:
             Remove xfail and work on functionality to fully fetch and parse user-defined codelists after higher priority functionality is finished.
         """
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE)
-        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
         codelist_3 = iati.core.default.codelists()['SectorCategory']

--- a/iati/validate.py
+++ b/iati/validate.py
@@ -16,5 +16,9 @@ def is_valid(dataset, schema):
 
     Warning:
         Parameters are likely to change in some manner.
+
+    Todo:
+        Consider if functionality should take account of differences between iati.core.Schema, iati.core.ActivtySchema and iati.core.OrganisationSchema
+
     """
     raise NotImplementedError


### PR DESCRIPTION
- Creates `ActivitySchema` and `OrganisationSchema` classes (both children of `iati.core.schema.Schema`)
- Changes how `iati.core.schema.Schema` (and subclasses) are instantiated (now using a filepath, rather than a schema name)
- Adds new functions `get_all_activity_schema_paths` and `get_all_organisation_schema_paths`
- Creates `iati.core.default.schema(schema_name)` as a means of instantiating a default IATI schema (and updates README with usage information)
- Renames functions for clarity: `find_all_*schema_paths` -> `get_all_*schema_paths`