### PR TITLE
Make iati.core.default.ruleset() return a Ruleset, not string

### DIFF
--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -97,26 +97,27 @@ def codelists(version=None, bypass_cache=False):
 
 
 def ruleset(version=None):
-    """Locate the default Ruleset.
+    """Locate the default Ruleset for the specified version of the Standard.
 
     Args:
         version (str): The version of the Standard to return the Ruleset for. Defaults to None. This means that the latest version of the Ruleset is returned.
 
     Returns:
-        str: A string.
-
-    Todo:
-        Parse string into a Ruleset.
+        iati.core.ruleset.Ruleset: The default Ruleset for the specified version of the Standard.
 
     Raises:
         ValueError: When a specified version is not a valid version of the IATI Standard.
+
+    Todo:
+        Actually handle versions, including errors.
 
     """
     name = 'standard_ruleset'
 
     path = iati.core.resources.get_ruleset_path(name, version)
     ruleset_str = iati.core.resources.load_as_string(path)
-    return ruleset_str
+
+    return iati.core.rulesets.Ruleset(ruleset_str)
 
 
 _SCHEMAS = {}

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -195,35 +195,91 @@ class RuleAtLeastOne(Rule):
         pass
 
 class RuleDateOrder(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "date_order"
+
+        super(RuleDateOrder, self).__init__(xpath_base, case)
 
 
 class RuleDependent(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "dependent"
+
+        super(RuleDependent, self).__init__(xpath_base, case)
 
 
 class RuleRegexMatches(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "regex_matches"
+
+        super(RuleRegexMatches, self).__init__(xpath_base, case)
 
 
 class RuleRegexNoMatches(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "regex_no_matches"
+
+        super(RuleRegexNoMatches, self).__init__(xpath_base, case)
 
 
 class RuleStartsWith(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "startswith"
+
+        super(RuleStartsWith, self).__init__(xpath_base, case)
 
 
 class RuleSum(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "sum"
+
+        super(RuleSum, self).__init__(xpath_base, case)
 
 
 class RuleUnique(Rule):
+    """A specific type of Rule.
 
-    pass
+    Todo:
+        Add docstring
+
+    """
+    def __init__(self, xpath_base, case):
+        self.name = "unique"
+
+        super(RuleUnique, self).__init__(xpath_base, case)

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -70,14 +70,14 @@ class Ruleset(object):
         """
         possible_rule_types = {
             'atleast_one': RuleAtLeastOne,
-            # 'date_order': RuleDateOrder,
-            # 'dependent': RuleDependent,
-            'no_more_than_one': RuleNoMoreThanOne #,
-            # 'regex_matches': RuleRegexMatches,
-            # 'regex_no_matches': RuleRegexNoMatches,
-            # 'startswith': RuleStartsWith,
-            # 'sum': RuleSum,
-            # 'unique': RuleUnique
+            'date_order': RuleDateOrder,
+            'dependent': RuleDependent,
+            'no_more_than_one': RuleNoMoreThanOne,
+            'regex_matches': RuleRegexMatches,
+            'regex_no_matches': RuleRegexNoMatches,
+            'startswith': RuleStartsWith,
+            'sum': RuleSum,
+            'unique': RuleUnique
         }
 
         return possible_rule_types[rule_type]
@@ -182,3 +182,37 @@ class RuleAtLeastOne(Rule):
     def implementation(self, dataset):
         """Check activity has at least one instance of a given case."""
         pass
+
+class RuleDateOrder(Rule):
+
+    pass
+
+
+class RuleDependent(Rule):
+
+    pass
+
+
+class RuleRegexMatches(Rule):
+
+    pass
+
+
+class RuleRegexNoMatches(Rule):
+
+    pass
+
+
+class RuleStartsWith(Rule):
+
+    pass
+
+
+class RuleSum(Rule):
+
+    pass
+
+
+class RuleUnique(Rule):
+
+    pass

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -53,14 +53,11 @@ class TestDefault(object):
         Todo:
             Handle multiple versions.
 
-            Check internal values beyond the ruleset being the correct type.
+            Check internal values beyond the Ruleset being the correct type.
         """
         ruleset = iati.core.default.ruleset()
 
-        # assert isinstance(ruleset, bytes)
-        # assert len(ruleset) > 2700
-        # assert len(ruleset) < 3500
-        # assert isinstance(ruleset, iati.core.rulesets.Ruleset)
+        assert isinstance(ruleset, iati.core.rulesets.Ruleset)
 
     def test_default_schemas(self):
         """Check that the default Schemas are correct.


### PR DESCRIPTION
To do this, all the various types of Rule subclass need creating.

These subclasses have been created, but need tests writing for them.