### PR TITLE
Remove need to refer to `xpath_base` when using a Rule

### DIFF
--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -285,8 +285,17 @@ class RuleDateOrder(Rule):
     def __init__(self, xpath_base, case):
         """Initialise a `date_order` rule."""
         self.name = "date_order"
+        self.SPECIAL_CASE = 'NOW'
 
         super(RuleDateOrder, self).__init__(xpath_base, case)
+
+    def _normalize_xpaths(self):
+        """Normalize xpaths by combining them with `xpath_base`."""
+        if self.less is not self.SPECIAL_CASE:
+            self.less = self._normalize_xpath(self.less)
+
+        if self.more is not self.SPECIAL_CASE:
+            self.more = self._normalize_xpath(self.more)
 
 
 class RuleDependent(Rule):

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -392,6 +392,12 @@ class RuleStartsWith(Rule):
         """Rule implementation method."""
         return True
 
+    def _normalize_xpaths(self):
+        """Normalize xpaths by combining them with `xpath_base`."""
+        super(RuleStartsWith, self)._normalize_xpaths()
+
+        self.start = self._normalize_xpath(self.start)
+
 
 class RuleSum(Rule):
     """A specific type of Rule.

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -126,6 +126,21 @@ class Rule(object):
         self.xpath_base = xpath_base
         self._valid_rule_configuration(case)
         self._set_case_attributes(case)
+        self._normalize_xpaths()
+
+    def _normalize_xpath(self, path):
+        """Normalize an xpath by combining it with `xpath_base`."""
+        if path == '':
+            return self.xpath_base
+        else:
+            return self.xpath_base + '/' + path
+
+    def _normalize_xpaths(self):
+        """Normalize xpaths by combining them with `xpath_base`."""
+        try:
+            self.paths = [self._normalize_xpath(path) for path in self.paths]
+        except AttributeError:
+            pass
 
     def _valid_rule_configuration(self, case):
         """Check that a configuration being passed into a Rule is valid for the given type of Rule.
@@ -198,11 +213,6 @@ class Rule(object):
 
         return partial_schema
 
-    def _extract_xpath_case(self, path):
-        """Return full XPath from `xpath_base` and `path`."""
-        full_path = self.xpath_base + '/' + path
-        return full_path
-
 
 class RuleNoMoreThanOne(Rule):
     """Representation of a Rule that checks that there is no more than one Element matching a given XPath.
@@ -230,8 +240,8 @@ class RuleNoMoreThanOne(Rule):
             Boolean value that changes depending on whether one or fewer cases are found in the dataset_tree.
 
         """
-        path = self.case['paths'][0]
-        return len(dataset_tree.findall(self._extract_xpath_case(path))) <= 1
+        path = self.paths[0]
+        return len(dataset_tree.findall(path)) <= 1
 
 
 class RuleAtLeastOne(Rule):
@@ -260,8 +270,8 @@ class RuleAtLeastOne(Rule):
             Boolean value that changes depending on whether the case is found in the dataset_tree.
 
         """
-        path = self.case['paths'][0]
-        return dataset_tree.find(self._extract_xpath_case(path)) is not None
+        path = self.paths[0]
+        return dataset_tree.find(path) is not None
 
 
 class RuleDateOrder(Rule):
@@ -318,11 +328,10 @@ class RuleRegexMatches(Rule):
 
     def is_valid_for(self, dataset_tree):
         """Check that the Element specified by `paths` matches the given regex case."""
-        paths = self.case['paths']
         pattern = re.compile(self.case['regex'])
 
-        for path in paths:
-            results = dataset_tree.findall(self._extract_xpath_case(path))
+        for path in self.paths:
+            results = dataset_tree.findall(path)
             for result in results:
                 return bool(pattern.match(result.text))
 
@@ -348,11 +357,10 @@ class RuleRegexNoMatches(Rule):
 
     def is_valid_for(self, dataset_tree):
         """Rule implementation method."""
-        paths = self.case['paths']
         pattern = re.compile(self.case['regex'])
 
-        for path in paths:
-            results = dataset_tree.findall(self._extract_xpath_case(path))
+        for path in self.paths:
+            results = dataset_tree.findall(path)
             for result in results:
                 return not bool(pattern.match(result.text))
 
@@ -416,12 +424,11 @@ class RuleUnique(Rule):
             Consider better methods for specifying which elements in the tree contain non-permitted duplication, such as bucket sort.
             Test with a ruleset that has multiple paths.
         """
-        paths = self.case['paths']
         original = list()
         unique = set()
 
-        for path in paths:
-            results = dataset_tree.findall(self._extract_xpath_case(path))
+        for path in self.paths:
+            results = dataset_tree.findall(path)
             for result in results:
                 original.append(result.text)
                 unique.add(result.text)

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -212,6 +212,14 @@ class RuleSubclassTestBase(object):
         """Check that a Rule subclass has the expected name."""
         assert basic_rule.name == rule_type
 
+    def test_rule_paths(self, basic_rule):
+        """Check that a Rule subclass has the expected paths."""
+        try:
+            for path in basic_rule.paths:
+                assert path.startswith(basic_rule.xpath_base)
+        except AttributeError:
+            pass
+
     def test_rule_invalid_case(self, rule_constructor, invalid_case):
         """Check that a rule cannot be instantiated when the case is invalid.
 
@@ -485,6 +493,20 @@ class TestRuleDateOrder(RuleSubclassTestBase):
     def this_rule_only_ruleset(self):
         """Ruleset contains only this Rule."""
         return None
+
+    def test_rule_paths_less(self, basic_rule):
+        """Check that the `less` value has been combined with the `xpath_base` where required."""
+        if basic_rule.less.endswith(basic_rule.SPECIAL_CASE):
+            assert basic_rule.less == basic_rule.SPECIAL_CASE
+        else:
+            assert basic_rule.less.startswith(basic_rule.xpath_base)
+
+    def test_rule_paths_more(self, basic_rule):
+        """Check that the `more` value has been combined with the `xpath_base` where required."""
+        if basic_rule.more.endswith(basic_rule.SPECIAL_CASE):
+            assert basic_rule.more == basic_rule.SPECIAL_CASE
+        else:
+            assert basic_rule.more.startswith(basic_rule.xpath_base)
 
 class TestRuleRegexMatches(RuleSubclassTestBase):
     """A container for tests relating to RuleRegexMatches."""

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -658,6 +658,10 @@ class TestRuleStartsWith(RuleSubclassTestBase):
         """Ruleset contains only this Rule."""
         return None
 
+    def test_rule_paths_less(self, basic_rule):
+        """Check that the `start` value has been combined with the `xpath_base`."""
+        assert basic_rule.start.startswith(basic_rule.xpath_base)
+
 
 class TestRuleUnique(RuleSubclassTestBase):
     """A container for tests relating to RuleUnique."""

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -658,7 +658,7 @@ class TestRuleStartsWith(RuleSubclassTestBase):
         """Ruleset contains only this Rule."""
         return None
 
-    def test_rule_paths_less(self, basic_rule):
+    def test_rule_paths_start(self, basic_rule):
         """Check that the `start` value has been combined with the `xpath_base`."""
         assert basic_rule.start.startswith(basic_rule.xpath_base)
 


### PR DESCRIPTION
This is done by combining it with paths at the point of initialisation.