### PR TITLE
Alphabetise no_more_than_one

### DIFF
--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -19,7 +19,7 @@ import iati.core.default
 import iati.core.utilities
 
 
-_VALID_RULE_TYPES = ["no_more_than_one", "atleast_one", "dependent", "sum", "date_order", "regex_matches", "regex_no_matches", "startswith", "unique"]
+_VALID_RULE_TYPES = ["atleast_one", "dependent", "sum", "date_order", "no_more_than_one", "regex_matches", "regex_no_matches", "startswith", "unique"]
 
 
 def locate_constructor_for_rule_type(rule_type):
@@ -204,36 +204,6 @@ class Rule(object):
         return full_path
 
 
-class RuleNoMoreThanOne(Rule):
-    """Representation of a Rule that checks that there is no more than one Element matching a given XPath.
-
-    Warning:
-        Rules have not yet been implemented. The structure of specific types of Rule will depend on how the base class is formed.
-
-        The name of specific types of Rule may better indicate that they are Rules.
-
-    """
-
-    def __init__(self, xpath_base, case):
-        """Initialise a `no_more_than_one` rule."""
-        self.name = "no_more_than_one"
-
-        super(RuleNoMoreThanOne, self).__init__(xpath_base, case)
-
-    def is_valid_for(self, dataset_tree):
-        """Check `dataset_tree` has no more than one instance of a given case for an Element.
-
-        Args:
-            dataset_tree: an etree created from an XML dataset.
-
-        Returns:
-            Boolean value that changes depending on whether one or fewer cases are found in the dataset_tree.
-
-        """
-        path = self.case['paths'][0]
-        return len(dataset_tree.findall(self._extract_xpath_case(path))) <= 1
-
-
 class RuleAtLeastOne(Rule):
     """Representation of a Rule that checks that there is at least one Element matching a given XPath.
 
@@ -294,6 +264,34 @@ class RuleDependent(Rule):
         super(RuleDependent, self).__init__(xpath_base, case)
 
 
+class RuleNoMoreThanOne(Rule):
+    """Representation of a Rule that checks that there is no more than one Element matching a given XPath.
+
+    Warning:
+        Rules have not yet been implemented. The structure of specific types of Rule will depend on how the base class is formed.
+
+        The name of specific types of Rule may better indicate that they are Rules.
+
+    """
+
+    def __init__(self, xpath_base, case):
+        """Initialise a `no_more_than_one` rule."""
+        self.name = "no_more_than_one"
+
+        super(RuleNoMoreThanOne, self).__init__(xpath_base, case)
+
+    def is_valid_for(self, dataset_tree):
+        """Check `dataset_tree` has no more than one instance of a given case for an Element.
+
+        Args:
+            dataset_tree: an etree created from an XML dataset.
+
+        Returns:
+            Boolean value that changes depending on whether one or fewer cases are found in the dataset_tree.
+
+        """
+        path = self.case['paths'][0]
+        return len(dataset_tree.findall(self._extract_xpath_case(path))) <= 1
 
 
 class RuleRegexMatches(Rule):

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -248,52 +248,6 @@ class RuleSubclassTestBase(object):
             assert not rule.is_valid_for(invalid_data_tree)
 
 
-class TestRuleNoMoreThanOne(RuleSubclassTestBase):
-    """A container for tests relating to RuleNoMoreThanOne."""
-
-    @pytest.fixture
-    def rule_type(self):
-        """Type of rule."""
-        return 'no_more_than_one'
-
-    @pytest.fixture(params=[
-        {'paths': ['']},  # empty path
-        {'paths': ['path_1']},  # single path
-        {'paths': ['path_1', 'path_2']},  # multiple paths
-        {'paths': ['path_1', 'path_1']}  # duplicate paths
-    ])
-    def valid_case(self, request):
-        """Permitted case for this rule."""
-        return request.param
-
-    @pytest.fixture(params=[
-        {'paths': []},  # empty path array
-        {'paths': 'path_1'},  # non-array `paths`
-        {'paths': [3]},  # non-string value in path array
-        {'paths': ['path_1', 3]},  # mixed string and non-string value in path array
-        {}  # empty dictionary
-    ])
-    def invalid_case(self, request):
-        """Non-permitted case for this rule."""
-        return request.param
-
-    @pytest.fixture
-    def invalid_data_tree(self):
-        """Invalid dataset etree for this Rule."""
-        return iati.core.tests.utilities.DATASET_TREE_FOR_NOMORETHANONE_RULE_INVALID
-
-    @pytest.fixture
-    def valid_data_tree(self):
-        """Return valid dataset etree for this Rule."""
-        return iati.core.tests.utilities.DATASET_TREE_FOR_NOMORETHANONE_RULE_VALID
-
-    @pytest.fixture
-    def this_rule_only_ruleset(self):
-        """Ruleset contains only this Rule."""
-        ruleset_str = iati.core.tests.utilities.NOMORETHANONE_RULESET_STR
-        return iati.core.Ruleset(ruleset_str)
-
-
 class TestRuleAtLeastOne(RuleSubclassTestBase):
     """A container for tests relating to RuleAtLeastOne."""
 
@@ -485,6 +439,53 @@ class TestRuleDateOrder(RuleSubclassTestBase):
     def this_rule_only_ruleset(self):
         """Ruleset contains only this Rule."""
         return None
+
+
+class TestRuleNoMoreThanOne(RuleSubclassTestBase):
+    """A container for tests relating to RuleNoMoreThanOne."""
+
+    @pytest.fixture
+    def rule_type(self):
+        """Type of rule."""
+        return 'no_more_than_one'
+
+    @pytest.fixture(params=[
+        {'paths': ['']},  # empty path
+        {'paths': ['path_1']},  # single path
+        {'paths': ['path_1', 'path_2']},  # multiple paths
+        {'paths': ['path_1', 'path_1']}  # duplicate paths
+    ])
+    def valid_case(self, request):
+        """Permitted case for this rule."""
+        return request.param
+
+    @pytest.fixture(params=[
+        {'paths': []},  # empty path array
+        {'paths': 'path_1'},  # non-array `paths`
+        {'paths': [3]},  # non-string value in path array
+        {'paths': ['path_1', 3]},  # mixed string and non-string value in path array
+        {}  # empty dictionary
+    ])
+    def invalid_case(self, request):
+        """Non-permitted case for this rule."""
+        return request.param
+
+    @pytest.fixture
+    def invalid_data_tree(self):
+        """Invalid dataset etree for this Rule."""
+        return iati.core.tests.utilities.DATASET_TREE_FOR_NOMORETHANONE_RULE_INVALID
+
+    @pytest.fixture
+    def valid_data_tree(self):
+        """Return valid dataset etree for this Rule."""
+        return iati.core.tests.utilities.DATASET_TREE_FOR_NOMORETHANONE_RULE_VALID
+
+    @pytest.fixture
+    def this_rule_only_ruleset(self):
+        """Ruleset contains only this Rule."""
+        ruleset_str = iati.core.tests.utilities.NOMORETHANONE_RULESET_STR
+        return iati.core.Ruleset(ruleset_str)
+
 
 class TestRuleRegexMatches(RuleSubclassTestBase):
     """A container for tests relating to RuleRegexMatches."""


### PR DESCRIPTION
Because no_more_than_one appeared early, it was not in alphabetical order with the other Rules. This brings it to the correct place in the alphabet.