### PR TITLE
Flatten schema in init

### DIFF
--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -81,8 +81,6 @@ class Schema(object):
             etree._ElementTree: The modified tree.
 
         Todo:
-            Check whether this is safe in the general case, so allowing it to be performed in __init__().
-
             Make resource locations more able to handle the general case.
 
             Consider moving this out of Schema().
@@ -130,12 +128,12 @@ class Schema(object):
         return tree
 
     def _flatten_includes(self):
-        """Flatten includes so that all nodes are accessible through lxml.
+        """For a Schema that contains an xsd:include element, flatten includes so that all nodes are accessible through lxml.
 
-        Identify the contents of files defined as `<xsd:include schemaLocation="NAME.xsd" />` and bring in the contents.
+        Identifies the contents of files defined as `<xsd:include schemaLocation="NAME.xsd" />` and bring in the contents.
 
-        Params:
-            tree (etree._ElementTree): The tree to flatten.
+        Updates:
+            self._schema_base_tree: To be the flattened schema. Makes no modification if the schema contains no xsd:include element.
 
         Todo:
             Consider moving this out of Schema().

--- a/iati/core/schemas.py
+++ b/iati/core/schemas.py
@@ -130,7 +130,7 @@ class Schema(object):
     def _flatten_includes(self):
         """For a Schema that contains an xsd:include element, flatten includes so that all nodes are accessible through lxml.
 
-        Identifies the contents of files defined as `<xsd:include schemaLocation="NAME.xsd" />` and bring in the contents.
+        I.e. Identify the contents of files defined as `<xsd:include schemaLocation="NAME.xsd" />` and bring in the contents.
 
         Updates:
             self._schema_base_tree: To be the flattened schema. Makes no modification if the schema contains no xsd:include element.
@@ -141,26 +141,26 @@ class Schema(object):
             Tidy this up.
 
         """
-        # change the include to a format that lxml can read
+        # Ensure that the include element is in a format that can be read by lxml
         tree = self._change_include_to_xinclude(self._schema_base_tree)
 
-        # adopt the included elements
+        # Adopt the included elements
         if tree is None:
             return
         else:
             tree.xinclude()
 
-        # remove nested schema elements
+        # Find any nested `xsd:schema` elements that exist within the newly flattened schema
         schema_xpath = (iati.core.constants.NAMESPACE + 'schema')
         for nested_schema_el in tree.getroot().findall(schema_xpath):
             if isinstance(nested_schema_el, etree._Element):
-                # move contents of nested schema elements up a level
+                # Move contents of nested schema elements up a level
                 for elem in nested_schema_el[:]:
-                    # do not duplicate an import statement
+                    # Do not duplicate an import statement
                     if 'schemaLocation' in elem.attrib:
                         continue
                     tree.getroot().insert(nested_schema_el.getparent().index(nested_schema_el) + 1, elem)
-        # remove the nested schema elements
+        # Remove the nested `xsd:schema` elements
         etree.strip_elements(tree.getroot(), schema_xpath)
 
     def get_xsd_element(self, xsd_element_name):

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -212,7 +212,7 @@ class TestSchemas(object):
         (default_activity_schema, 'element-name-that-does-not-exist', type(None)),
         (default_organisation_schema, 'iati-organisations', etree._Element),
         (default_organisation_schema, 'organisation-identifier', etree._Element),  # The 'organisation-identifier' is defined within the 'iati-organisation' element.
-        (default_organisation_schema, 'sector', type(None))
+        (default_organisation_schema, 'sector', type(None))  # There is no 'sector' element within the organisation schema.
     ])
     def test_get_xsd_element(self, schema_type, xsd_element_name, expected_type):
         """Check that an lxml object is returned to represent an XSD element.

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -226,15 +226,15 @@ class TestSchemas(object):
 
         assert isinstance(result, expected_type)
 
-    @pytest.mark.parametrize("schema_type, xsd_element_name", [
-        (default_activity_schema, 'iati-activities'),
-        (default_activity_schema, 'contact-info'),
-        (default_activity_schema, 'iati-identifier'),  # Contains no child elements
-        (default_organisation_schema, 'iati-organisations'),
-        (default_organisation_schema, 'total-budget'),
-        (default_organisation_schema, 'organisation-identifier')  # Contains no child elements
+    @pytest.mark.parametrize("schema_type, xsd_element_name, num_expected_child_elements", [
+        (default_activity_schema, 'iati-activities', 1),
+        (default_activity_schema, 'contact-info', 8),
+        (default_activity_schema, 'iati-identifier', 0),  # Contains no child elements
+        (default_organisation_schema, 'iati-organisations', 1),
+        (default_organisation_schema, 'total-budget', 4),
+        (default_organisation_schema, 'organisation-identifier', 0)  # Contains no child elements
     ])
-    def test_get_child_xsd_elements(self, schema_type, xsd_element_name):
+    def test_get_child_xsd_elements(self, schema_type, xsd_element_name, num_expected_child_elements):
         """Check that a list of lxml objects are returned to represent all child XSD elements. Also check that each item in the result is of the expected type.
 
         Todo
@@ -246,18 +246,19 @@ class TestSchemas(object):
         result = schema.get_child_xsd_elements(parent_element)
 
         assert isinstance(result, list)
+        assert len(result) == num_expected_child_elements
         for item in result:
             assert isinstance(item, etree._Element)
 
-    @pytest.mark.parametrize("schema_type, xsd_element_name", [
-        (default_activity_schema, 'iati-activities'),
-        (default_activity_schema, 'iati-activity'),
-        (default_activity_schema, 'iati-identifier'),  # No attributes
-        (default_organisation_schema, 'iati-organisations'),
-        (default_organisation_schema, 'iati-organisation'),
-        (default_organisation_schema, 'organisation-identifier')  # No attributes
+    @pytest.mark.parametrize("schema_type, xsd_element_name, num_expected_attributes", [
+        (default_activity_schema, 'iati-activities', 3),
+        (default_activity_schema, 'iati-activity', 6),
+        (default_activity_schema, 'iati-identifier', 0),  # Contains no attributes
+        (default_organisation_schema, 'iati-organisations', 2),
+        (default_organisation_schema, 'iati-organisation', 3),
+        (default_organisation_schema, 'organisation-identifier', 0)  # Contains no attributes
     ])
-    def test_get_attributes_in_xsd_element(self, schema_type, xsd_element_name):
+    def test_get_attributes_in_xsd_element(self, schema_type, xsd_element_name, num_expected_attributes):
         """Check that a list of lxml objects are returned to represent the attributes contained within a given XSD element. Also check that each item in the result is of the expected type.
 
         Todo
@@ -269,6 +270,7 @@ class TestSchemas(object):
         result = schema.get_attributes_in_xsd_element(element)
 
         assert isinstance(result, list)
+        assert len(result) == num_expected_attributes
         for item in result:
             assert isinstance(item, etree._Element)
 


### PR DESCRIPTION
This makes _flatten_includes a private method, and adds to the `__init__` method
of `iati.core.Schema`. Also simplifies existing tests, and adds a test for
a schema that does not feature an include statement.