### PR TITLE
Deal with incomplete Codelists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # pyenv folder specified in README
 pyenv/
+pyenv2/
 
 # defined files to ignore
 ignore_*

--- a/iati/core/codelists.py
+++ b/iati/core/codelists.py
@@ -75,6 +75,11 @@ class Codelist(object):
                     name = ''
                 self.codes.add(iati.core.Code(value, name))
 
+            try:
+                self.complete = True if tree.attrib['complete'] == '1' else False
+            except KeyError:
+                pass
+
         self.codes = set()
         self.name = name
 

--- a/iati/core/resources/test_data/202/valid_iati_incomplete_codelist_code_not_present.xml
+++ b/iati/core/resources/test_data/202/valid_iati_incomplete_codelist_code_not_present.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+    <recipient-country code="a-code-not-on-the-codelist" />
+  </iati-activity>
+</iati-activities>

--- a/iati/core/resources/test_data/202/valid_iati_incomplete_codelist_code_present.xml
+++ b/iati/core/resources/test_data/202/valid_iati_incomplete_codelist_code_present.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<iati-activities version="2.02">
+  <iati-activity>
+    <iati-identifier></iati-identifier>
+    <reporting-org type="40" ref="AA-AAA-123456789">
+      <narrative>Organisation name</narrative>
+    </reporting-org>
+    <title>
+      <narrative>Xxxxxxx</narrative>
+    </title>
+    <description>
+      <narrative>Xxxxxxx</narrative>
+    </description>
+    <participating-org role="2"></participating-org>
+    <activity-status code="2"/>
+    <activity-date type="1" iso-date="2023-11-27"/>
+    <recipient-country code="GB" />
+  </iati-activity>
+</iati-activities>

--- a/iati/core/tests/test_codelists.py
+++ b/iati/core/tests/test_codelists.py
@@ -80,6 +80,24 @@ class TestCodelists(object):
             assert code.name in code_names
             assert code.value in code_values
 
+    def test_codelist_complete(self):
+        """Check that a Codelist can be generated from an XML codelist definition."""
+        codelist_name = 'BudgetType'
+        path = iati.core.resources.get_codelist_path(codelist_name)
+        xml_str = iati.core.resources.load_as_string(path)
+        codelist = iati.core.Codelist(codelist_name, xml=xml_str)
+
+        assert codelist.complete == True
+
+    def test_codelist_incomplete(self):
+        """Check that a Codelist can be generated from an XML codelist definition."""
+        codelist_name = 'Country'
+        path = iati.core.resources.get_codelist_path(codelist_name)
+        xml_str = iati.core.resources.load_as_string(path)
+        codelist = iati.core.Codelist(codelist_name, xml=xml_str)
+
+        assert codelist.complete == False
+
     def test_codelist_type_xsd(self, name_to_set):
         """Check that a Codelist can turn itself into a type to use for validation."""
         code_value_to_set = "test Code value"

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -43,6 +43,11 @@ XML_STR_VALID_IATI_INVALID_CODES_MULTIPLE_XPATHS_FOR_CODELIST_SECOND = iati.core
 
 The first value that should be from the Codelist is invalid, while the second is valid."""
 
+XML_STR_VALID_IATI_INCOMPLETE_CODELIST_CODE_PRESENT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_incomplete_codelist_code_present'))
+"""A string containing valid IATI XML with an attribute requiring a value from an incomplete Codelist. The attribute value is on this Codelist."""
+XML_STR_VALID_IATI_INCOMPLETE_CODELIST_CODE_NOT_PRESENT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_incomplete_codelist_code_not_present'))
+"""A string containing valid IATI XML with an attribute requiring a value from an incomplete Codelist. The attribute value is not on this Codelist."""
+
 XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_explicit'))
 """A string contains valid IATI XML containing an element that uses vocabularies. Explicitly defines default vocab and uses code from that list."""
 XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_implicit'))

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -97,6 +97,21 @@ class TestValidateCodelist(object):
 
         return schema
 
+    @pytest.fixture
+    def schema_incomplete_codelist(self):
+        """A schema with an incomplete Codelist added.
+
+        Returns:
+            A valid activity schema with the OrganisationType Codelist added.
+
+        """
+        schema = iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+        codelist = iati.core.default.codelists()['Country']
+
+        schema.codelists.add(codelist)
+
+        return schema
+
     def test_basic_validation_codelist_valid(self, schema_version):
         """Perform data validation against valid IATI XML that has valid Codelist values."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
@@ -146,7 +161,21 @@ class TestValidateCodelist(object):
         assert iati.validate.is_iati_xml(data, schema_org_type)
         assert not iati.validate.is_valid(data, schema_org_type)
 
+    def test_basic_validation_codelist_incomplete_present(self, schema_incomplete_codelist):
+        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list."""
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INCOMPLETE_CODELIST_CODE_PRESENT)
 
+        assert iati.validate.is_xml(data.xml_str)
+        assert iati.validate.is_iati_xml(data, schema_incomplete_codelist)
+        assert iati.validate.is_valid(data, schema_incomplete_codelist)
+
+    def test_basic_validation_codelist_incomplete_not_present(self, schema_incomplete_codelist):
+        """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is not on the list."""
+        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INCOMPLETE_CODELIST_CODE_NOT_PRESENT)
+
+        assert iati.validate.is_xml(data.xml_str)
+        assert iati.validate.is_iati_xml(data, schema_incomplete_codelist)
+        assert iati.validate.is_valid(data, schema_incomplete_codelist)
 
 class TestValidateVocabularies(object):
     """A container for tests relating to validation of vocabularies and associated Codelists."""

--- a/iati/validate.py
+++ b/iati/validate.py
@@ -22,6 +22,9 @@ def _correct_codes(dataset, codelist):
     mappings = iati.core.default.codelist_mapping()
     codes_to_check = []
 
+    if not codelist.complete:
+        return True
+
     for mapping in mappings[codelist.name]:
         base_xpath = mapping['xpath']
         condition = mapping['condition']


### PR DESCRIPTION
In an incomplete Codelist, it is deemed that not all values are present. As such, using a value not on the Codelist leads to valid data.