### PR TITLE
Parallel tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # pyenv folder specified in README
 pyenv/
+pyenv2/
 
 # defined files to ignore
 ignore_*

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,7 @@ lint: $(IATI_FOLDER)
 
 test: $(IATI_FOLDER)
 	py.test --cov-report term-missing:skip-covered --cov=$(IATI_FOLDER) $(IATI_FOLDER)
+
+
+testp: $(IATI_FOLDER)
+	py.test --cov-report term-missing:skip-covered --cov=$(IATI_FOLDER) -n 2 $(IATI_FOLDER)

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -110,6 +110,8 @@ def find_parameter_by_type(types, type_as_specified=True):
     else:
         valid_keys = valid_keys_as_specified
 
+    valid_keys = sorted(valid_keys)
+
     results = []
 
     for key in valid_keys:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ radon==2.0.2 # rq.filter: <3.0
 # testing tools
 pytest==3.0.5 # rq.filter: <4.0
 pytest-cov==2.4.0 # rq.filter: <3.0
+pytest-xdist==1.18.1 # rq.filter: <2.0
 
 # python2/python3 compatibility library
 six==1.10.0 # rq.filter: <2.0


### PR DESCRIPTION
This makes the tests parallisable.

The primary change is that dictionary keys in `find_parameter_by_type` are sorted so that the order of the returned array is the same every time.

Note that running tests in parallel is currently slower than running them sequentially.