### PR TITLE
Class-based Validation Error Log

### DIFF
--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -406,12 +406,12 @@ class TestValidatorDetailedOutput(ValidateCodelistsBase):
 
         result = iati.validator.full_validation(data, schema_version)[0]
 
-        assert isinstance(result, dict)
-        assert result['status'] == 'error'
-        assert result['line_number'] == 3
-        assert result['context'] == '\n'.join(xml_str.split('\n')[1:4])
-        assert 'Version' in result['info']
-        assert 'Version' in result['help']
+        assert isinstance(result, iati.validator.ValidationError)
+        assert result.status == 'error'
+        assert result.line_number == 3
+        assert result.context == '\n'.join(xml_str.split('\n')[1:4])
+        assert 'Version' in result.info
+        assert 'Version' in result.help
 
     def test_basic_validation_codelist_incomplete_present_detailed_output(self, schema_incomplete_codelist):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list.
@@ -433,8 +433,8 @@ class TestValidatorDetailedOutput(ValidateCodelistsBase):
 
         result = iati.validator.full_validation(data, schema_incomplete_codelist)[0]
 
-        assert result['line_number'] == 18
-        assert result['context'] == '\n'.join(xml_str.split('\n')[16:19])
-        assert result['status'] == 'warning'
-        assert 'Country' in result['info']
-        assert 'Country' in result['help']
+        assert result.line_number == 18
+        assert result.context == '\n'.join(xml_str.split('\n')[16:19])
+        assert result.status == 'warning'
+        assert 'Country' in result.info
+        assert 'Country' in result.help

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -24,9 +24,15 @@ class TestValidationError(object):
 
     def test_error_log_init_valid_name(self):
         """Test that a ValidationError can be created when provided a valid name."""
-        err = iati.validator.ValidationError('err-code-not-on-codelist')
+        err_name = 'err-code-not-on-codelist'
+        err = iati.validator.ValidationError(err_name)
+        err_detail = iati.validator._ERROR_CODES[err_name]
 
         assert isinstance(err, iati.validator.ValidationError)
+        assert err.category == err_detail['category']
+        assert err.description == err_detail['description']
+        assert err.info == err_detail['info']
+        assert err.help == err_detail['help']
 
 
 class TestValidationErrorLog(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -7,15 +7,26 @@ import iati.core.tests.utilities
 import iati.validator
 
 
+class TestValidationError(object):
+    """A container for tests relating to ValidationErrors."""
+
+
+    def test_validation_error_init(self):
+        """Test that a ValidationError can be created."""
+        err = iati.validator.ValidationError()
+
+        assert isinstance(err, iati.validator.ValidationError)
+
+
 class TestValidationErrorLog(object):
     """A container for tests relating to Validation Error Logs."""
 
 
     def test_error_log_init(self):
         """Test that a validator ErrorLog can be created and acts as a set."""
-        error_log = iati.validator.ErrorLog()
+        error_log = iati.validator.ValidationErrorLog()
 
-        assert isinstance(error_log, iati.validator.ErrorLog)
+        assert isinstance(error_log, iati.validator.ValidationErrorLog)
         assert isinstance(error_log, set)
 
 

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -421,7 +421,6 @@ class TestValidatorDetailedOutput(ValidateCodelistsBase):
 
         result = iati.validator.full_validation(data, schema_incomplete_codelist)
 
-        assert isinstance(result, list)
         assert len(result) == 0
 
     def test_basic_validation_codelist_incomplete_not_present_detailed_output(self, schema_incomplete_codelist):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -45,14 +45,13 @@ class TestValidationErrorLog(object):
     def test_error_log_init(self, error_log):
         """Test that a validator ErrorLog can be created and acts as a set."""
         assert isinstance(error_log, iati.validator.ValidationErrorLog)
-        assert isinstance(error_log, list)
         assert not error_log.contains_errors()
 
-    def test_error_log_add_errors(self, error_log):
-        """Test that errors are identified as errors when added to the error log."""
+    def test_error_log_append_errors(self, error_log):
+        """Test that errors are identified as errors when appended to the error log."""
         err_name = 'err-code-not-on-codelist'
         err = iati.validator.ValidationError(err_name)
-        error_log.append(err)
+        error_log.add(err)
 
         assert len(error_log) == 1
         assert error_log.contains_errors()
@@ -61,11 +60,25 @@ class TestValidationErrorLog(object):
         """Test that warnings are not identified as errors when added to the error log."""
         warning_name = 'warn-code-not-on-codelist'
         warning = iati.validator.ValidationError(warning_name)
-        error_log.append(warning)
+        error_log.add(warning)
 
         assert len(error_log) == 1
         assert not error_log.contains_errors()
 
+    @pytest.mark.parametrize("not_ValidationError", iati.core.tests.utilities.find_parameter_by_type([], False))
+    def test_error_log_add_incorrect_type(self, error_log, not_ValidationError):
+        """Test that you may only add ValidationErrors to a ValidationErrorLog."""
+        with pytest.raises(TypeError):
+            error_log.add(not_ValidationError)
+
+    @pytest.mark.parametrize("potential_ValidationError", iati.core.tests.utilities.find_parameter_by_type([], False) + [iati.validator.ValidationError('err-code-not-on-codelist')])
+    def test_error_log_set_index_incorrect_type(self, error_log, potential_ValidationError):
+        """Test that you may only assign ValidationErrors to a ValidationErrorLog."""
+        warning = iati.validator.ValidationError('warn-code-not-on-codelist')
+        error_log.add(warning)
+
+        with pytest.raises(NotImplementedError):
+            error_log[0] = potential_ValidationError
 
 class TestValidation(object):
     """A container for tests relating to validation."""

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -11,9 +11,20 @@ class TestValidationError(object):
     """A container for tests relating to ValidationErrors."""
 
 
-    def test_validation_error_init(self):
-        """Test that a ValidationError can be created."""
-        err = iati.validator.ValidationError()
+    def test_validation_error_init_no_name(self):
+        """Test that a ValidationError cannot be created with no name provided."""
+        with pytest.raises(TypeError):
+            iati.validator.ValidationError()
+
+    @pytest.mark.parametrize("invalid_err_name", iati.core.tests.utilities.find_parameter_by_type([], False))
+    def test_validation_error_init_bad_name_type(self, invalid_err_name):
+        """Test that a ValidationError cannot be created with a name that does not exist."""
+        with pytest.raises(ValueError):
+            iati.validator.ValidationError(invalid_err_name)
+
+    def test_error_log_init_valid_name(self):
+        """Test that a ValidationError can be created when provided a valid name."""
+        err = iati.validator.ValidationError('err-code-not-on-codelist')
 
         assert isinstance(err, iati.validator.ValidationError)
 

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -90,9 +90,28 @@ class TestValidationErrorLog(object):
             error_log_with_warning[0] = potential_ValidationError
 
     def test_error_log_equality_single_error(self, error_log_with_error, error_log_with_warning):
-        """Test equality between Error Logs with a single error in them."""
+        """Test equality between a pair of ValidationErrorLogs.
+
+        Each error log contains the same number of errors. Each has different errors.
+        """
         assert not error_log_with_error == error_log_with_warning
+        assert not error_log_with_warning == error_log_with_error
         assert error_log_with_error != error_log_with_warning
+        assert error_log_with_warning != error_log_with_error
+
+    def test_error_log_equality_extended_log(self, error_log, error_log_with_error):
+        """Test equality between a pair of ValidationErrorLogs.
+
+        One error log is empty. The other has errors in.
+        The empty log is extended with the values in the log that has values.
+        """
+        assert error_log != error_log_with_error
+        assert error_log_with_error != error_log
+
+        error_log.extend(error_log_with_error)
+
+        assert error_log == error_log_with_error
+        assert error_log_with_error == error_log
 
 
 class TestValidation(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -43,19 +43,21 @@ class TestValidationErrorLog(object):
         return iati.validator.ValidationErrorLog()
 
     @pytest.fixture
-    def error_log_with_error(self, error_log):
+    def error_log_with_error(self):
         """An error log with an error added."""
         err_name = 'err-code-not-on-codelist'
         error = iati.validator.ValidationError(err_name)
+        error_log = iati.validator.ValidationErrorLog()
         error_log.add(error)
 
         return error_log
 
     @pytest.fixture
-    def error_log_with_warning(self, error_log):
+    def error_log_with_warning(self):
         """An error log with a warning added."""
         warning_name = 'warn-code-not-on-codelist'
         warning = iati.validator.ValidationError(warning_name)
+        error_log = iati.validator.ValidationErrorLog()
         error_log.add(warning)
 
         return error_log
@@ -86,6 +88,12 @@ class TestValidationErrorLog(object):
         """Test that you may not add values to an error log via index assignment."""
         with pytest.raises(TypeError):
             error_log_with_warning[0] = potential_ValidationError
+
+    def test_error_log_equality_single_error(self, error_log_with_error, error_log_with_warning):
+        """Test equality between Error Logs with a single error in them."""
+        assert not error_log_with_error == error_log_with_warning
+        assert error_log_with_error != error_log_with_warning
+
 
 class TestValidation(object):
     """A container for tests relating to validation."""

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -7,6 +7,18 @@ import iati.core.tests.utilities
 import iati.validator
 
 
+class TestValidationErrorLog(object):
+    """A container for tests relating to Validation Error Logs."""
+
+
+    def test_error_log_init(self):
+        """Test that a validator ErrorLog can be created and acts as a set."""
+        error_log = iati.validator.ErrorLog()
+
+        assert isinstance(error_log, iati.validator.ErrorLog)
+        assert isinstance(error_log, set)
+
+
 class TestValidation(object):
     """A container for tests relating to validation."""
 

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -10,7 +10,6 @@ import iati.validator
 class TestValidationError(object):
     """A container for tests relating to ValidationErrors."""
 
-
     def test_validation_error_init_no_name(self):
         """Test that a ValidationError cannot be created with no name provided."""
         with pytest.raises(TypeError):
@@ -38,13 +37,34 @@ class TestValidationError(object):
 class TestValidationErrorLog(object):
     """A container for tests relating to Validation Error Logs."""
 
+    @pytest.fixture
+    def error_log(self):
+        """A basic, error log that is initially empty."""
+        return iati.validator.ValidationErrorLog()
 
-    def test_error_log_init(self):
+    def test_error_log_init(self, error_log):
         """Test that a validator ErrorLog can be created and acts as a set."""
-        error_log = iati.validator.ValidationErrorLog()
-
         assert isinstance(error_log, iati.validator.ValidationErrorLog)
         assert isinstance(error_log, list)
+        assert not error_log.contains_errors()
+
+    def test_error_log_add_errors(self, error_log):
+        """Test that errors are identified as errors when added to the error log."""
+        err_name = 'err-code-not-on-codelist'
+        err = iati.validator.ValidationError(err_name)
+        error_log.append(err)
+
+        assert len(error_log) == 1
+        assert error_log.contains_errors()
+
+    def test_error_log_add_warnings(self, error_log):
+        """Test that warnings are not identified as errors when added to the error log."""
+        warning_name = 'warn-code-not-on-codelist'
+        warning = iati.validator.ValidationError(warning_name)
+        error_log.append(warning)
+
+        assert len(error_log) == 1
+        assert not error_log.contains_errors()
 
 
 class TestValidation(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -44,7 +44,7 @@ class TestValidationErrorLog(object):
         error_log = iati.validator.ValidationErrorLog()
 
         assert isinstance(error_log, iati.validator.ValidationErrorLog)
-        assert isinstance(error_log, set)
+        assert isinstance(error_log, list)
 
 
 class TestValidation(object):
@@ -397,7 +397,7 @@ class TestValidatorDetailedOutput(ValidateCodelistsBase):
         """Perform data validation against valid IATI XML that has valid Codelist values.  Obtain detailed error output."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
 
-        assert iati.validator.full_validation(data, schema_version) == []
+        assert iati.validator.full_validation(data, schema_version) == iati.validator.ValidationErrorLog()
 
     def test_basic_validation_codelist_invalid_detailed_output(self, schema_version):
         """Perform data validation against valid IATI XML that has invalid Codelist values."""

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -70,7 +70,11 @@ class ValidationErrorLog(object):
 
     def __eq__(self, other):
         """Test equality with another object."""
-        return self._values == other._values
+        for val in self._values:
+            if not val in other._values:
+                return False
+
+        return True
 
     def add(self, value):
         """Add a value to the Error Log.

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -50,12 +50,7 @@ class ValidationError(object):
 
 
 class ValidationErrorLog(list):
-    """A container to keep track of a set of ValidationErrors.
-
-    Todo:
-        Consider switching to extending a set.
-
-    """
+    """A container to keep track of a set of ValidationErrors."""
 
     pass
 
@@ -149,7 +144,7 @@ def _correct_codelist_values(dataset, schema, error_log=False):
 
     for codelist in schema.codelists:
         if error_log:
-            errors = errors + _correct_codes(dataset, codelist, error_log)
+            errors.extend(_correct_codes(dataset, codelist, error_log))
         else:
             correct_for_codelist = _correct_codes(dataset, codelist)
             if not correct_for_codelist:

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -49,8 +49,69 @@ class ValidationError(object):
             pass
 
 
-class ValidationErrorLog(list):
+class ValidationErrorLog(object):
     """A container to keep track of a set of ValidationErrors."""
+
+    def __init__(self):
+        """Initialise the error log."""
+        self._values = []
+
+    def __iter__(self):
+        """Return an iterator."""
+        return iter(self._values)
+
+    def __len__(self):
+        """The number of items in the ErrorLog."""
+        return len(self._values)
+
+    def __getitem__(self, key):
+        """Return an item with the specified key."""
+        return self._values[key]
+
+    def __setitem__(self, key, value):
+        """Prevent assignment by keys.
+
+        This is assignments such as `list[key] = val`.
+
+        Raises:
+            NotImplementedError: In all cases where this is called and parameters are correct.
+        """
+        raise NotImplementedError('Items in the error log may not be set directly. Please use `append() instead.')
+
+    def __eq__(self, other):
+        """Test equality with another object."""
+        return self._values == other._values
+
+    def add(self, value):
+        """Add a value to the Error Log.
+
+        Args:
+            value (iati.validator.ValidationError): The ValidationError to add to the Error Log.
+
+        Raises:
+            TypeError: When attempting to set an item that is not a ValidationError.
+
+        """
+        if not isinstance(value, iati.validator.ValidationError):
+            raise TypeError('Only ValidationErrors may be added to a ValidationErrorLog.')
+
+        self._values.append(value)
+
+    def extend(self, values):
+        """Extend the ErrorLog with ValidationErrors from an iterable.
+
+        Args:
+            values (iterable): An iterable containing ValidationErrors.
+
+        Note:
+            All ValidationErrors within the iterable shall be added. Any other contents shall not, and will fail to be added silently.
+
+        """
+        for value in values:
+            try:
+               self.add(value)
+            except TypeError:
+                pass
 
     def contains_errors(self):
         """Determine whether there are errors contained.
@@ -65,6 +126,7 @@ class ValidationErrorLog(list):
         actual_errors = [err for err in self if err.status == 'error']
 
         return len(actual_errors) > 0
+
 
 
 _ERROR_CODES = {
@@ -124,7 +186,7 @@ def _check_codes(dataset, codelist):
 
                 error.actual_value = code
 
-                error_log.append(error)
+                error_log.add(error)
 
     return error_log
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -4,6 +4,10 @@ from lxml import etree
 import iati.core.default
 
 
+class ErrorLog(set):
+    pass
+
+
 _ERROR_CODES = {
     'err-code-not-on-codelist': {
         'category': 'codelist',

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -70,6 +70,9 @@ class ValidationErrorLog(object):
 
     def __eq__(self, other):
         """Test equality with another object."""
+        if len(self._values) != len(other._values):
+            return False
+
         for val in self._values:
             if not val in other._values:
                 return False

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -50,7 +50,11 @@ class ValidationError(object):
 
 
 class ValidationErrorLog(object):
-    """A container to keep track of a set of ValidationErrors."""
+    """A container to keep track of a set of ValidationErrors.
+
+    ValidationErrors may be added to the log.
+
+    """
 
     def __init__(self):
         """Initialise the error log."""
@@ -80,7 +84,7 @@ class ValidationErrorLog(object):
         return True
 
     def add(self, value):
-        """Add a value to the Error Log.
+        """Add a single ValidationError to the Error Log.
 
         Args:
             value (iati.validator.ValidationError): The ValidationError to add to the Error Log.
@@ -111,7 +115,7 @@ class ValidationErrorLog(object):
                 pass
 
     def contains_errors(self):
-        """Determine whether there are errors contained.
+        """Determine whether there are errors contained within the ErrorLog.
 
         Note:
             The error log may contain warnings, or may be empty.
@@ -123,6 +127,20 @@ class ValidationErrorLog(object):
         actual_errors = [err for err in self if err.status == 'error']
 
         return len(actual_errors) > 0
+
+    def contains_warnings(self):
+        """Determine whether there are warnings contained within the ErrorLog.
+
+        Note:
+            The error log may contain errors, or may be empty.
+
+        Returns:
+            bool: Whether there are warnings within this error log.
+
+        """
+        actual_warnings = [err for err in self if err.status == 'warning']
+
+        return len(actual_warnings) > 0
 
 
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -36,12 +36,16 @@ class ValidationError(object):
         try:
             self.help = self.help.format(**calling_locals)
             self.info = self.info.format(**calling_locals)
+        except KeyError as missing_var_err:
+            # raise NameError('The calling scope must contain a `{missing_var_err.args[0]}` variable for providing information for the error message.'.format(**locals()))
+            pass
 
-            # set general attributes for this type of error that require context from the calling scope
+        # set general attributes for this type of error that require context from the calling scope
+        try:
             self.line_number = calling_locals['line_number']
             self.context = calling_locals['dataset'].source_around_line(self.line_number)
-        except KeyError as missing_var_err:
-            # raise NameError('The calling scope must contain a `{missing_var_err.args[0]}` variable.'.format(**locals()))
+        except KeyError:
+            # TODO: Determine what the defaults should be should the appropriate values not be available
             pass
 
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -49,8 +49,13 @@ class ValidationError(object):
             pass
 
 
-class ValidationErrorLog(set):
-    """A container to keep track of a set of ValidationErrors."""
+class ValidationErrorLog(list):
+    """A container to keep track of a set of ValidationErrors.
+
+    Todo:
+        Consider switching to extending a set.
+
+    """
 
     pass
 
@@ -84,7 +89,7 @@ def _correct_codes(dataset, codelist, error_log=False):
         list of dict: If `error_log` is True. A list of the errors that occurred.
 
     """
-    errors = []
+    errors = ValidationErrorLog()
     mappings = iati.core.default.codelist_mapping()
 
     if not error_log and not codelist.complete:
@@ -140,7 +145,7 @@ def _correct_codelist_values(dataset, schema, error_log=False):
         list of dict: If `error_log` is True. A list of the errors that occurred.
 
     """
-    errors = []
+    errors = ValidationErrorLog()
 
     for codelist in schema.codelists:
         if error_log:

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -7,8 +7,20 @@ import iati.core.default
 class ValidationError(object):
     """A base class to encapsulate information about Validation Errors."""
 
-    pass
+    def __init__(self, err_name):
+        """Create a new ValidationError.
 
+        Args:
+            err_name (str): The name of the error to use as a base.
+
+        Raises:
+            ValueError: If there is no base error with the provided name.
+
+        """
+        try:
+            _ = _ERROR_CODES[err_name]
+        except (KeyError, TypeError):
+            raise ValueError('{err_name} is not a known type of ValidationError.'.format(**locals()))
 
 
 class ValidationErrorLog(set):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -18,9 +18,12 @@ class ValidationError(object):
 
         """
         try:
-            _ = _ERROR_CODES[err_name]
+            err_detail = _ERROR_CODES[err_name]
         except (KeyError, TypeError):
             raise ValueError('{err_name} is not a known type of ValidationError.'.format(**locals()))
+
+        for key, val in err_detail.items():
+            setattr(self, key, val)
 
 
 class ValidationErrorLog(set):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -68,16 +68,6 @@ class ValidationErrorLog(object):
         """Return an item with the specified key."""
         return self._values[key]
 
-    def __setitem__(self, key, value):
-        """Prevent assignment by keys.
-
-        This is assignments such as `list[key] = val`.
-
-        Raises:
-            NotImplementedError: In all cases where this is called and parameters are correct.
-        """
-        raise NotImplementedError('Items in the error log may not be set directly. Please use `append() instead.')
-
     def __eq__(self, other):
         """Test equality with another object."""
         return self._values == other._values

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -4,7 +4,16 @@ from lxml import etree
 import iati.core.default
 
 
-class ErrorLog(set):
+class ValidationError(object):
+    """A base class to encapsulate information about Validation Errors."""
+
+    pass
+
+
+
+class ValidationErrorLog(set):
+    """A container to keep track of a set of ValidationErrors."""
+
     pass
 
 


### PR DESCRIPTION
Implement Validation errors using classes.

This will be based loosely on the [cerberus](http://docs.python-cerberus.org/en/stable/errors.html) implementation, providing a public API along the lines of `ValidationError in ErrorList`.

Alternatives that have been looked at but rejected at this point:

* [voluptuous](https://pypi.python.org/pypi/voluptuous) - `raise Invalid()` - we need to keep track of errors, not raise them
* [JSONSchema](http://python-jsonschema.readthedocs.io/en/latest/errors/) - `ValidationError(_Error)` on `Validator` - there is currently not a distinct `Validator` object, and putting such a thing on, eg, a `Dataset` doesn't seem appropriate
* [lxml](https://github.com/lxml/lxml/blob/621d8d9f0c2dda3f97ffa6eec568fc7eea98ebb1/src/lxml/xmlerror.pxi) - `_LogEntry in _ListLogError(_BaseErrorLog)` - this is like the cerberus implementation, but with a deeper class hierarchy. May be useful reference in the future, butis too complex for this point in time.
* [requests](https://github.com/requests/requests/blob/master/requests/exceptions.py) - `ValidationError` - this defines a lot of different stub classes