### PR TITLE
Add `is_xml()` errors to error log

### DIFF
--- a/iati/core/data.py
+++ b/iati/core/data.py
@@ -3,6 +3,7 @@ import sys
 from lxml import etree
 import iati.core.exceptions
 import iati.core.utilities
+import iati.validator
 
 
 class Dataset(object):
@@ -63,7 +64,7 @@ class Dataset(object):
         """Return a string representation of the XML being represented.
 
         Raises:
-            ValueError: If a value that is being assigned is not a valid XML string.
+            iati.core.exceptions.ValidationError: If a value that is being assigned is not a valid XML string.
             TypeError: If a value that is being assigned is not a string at all.
 
         Todo:
@@ -90,13 +91,17 @@ class Dataset(object):
                 else:
                     value_stripped_bytes = value_stripped
 
-                self.xml_tree = etree.fromstring(value_stripped_bytes)
-                self._xml_str = value_stripped
-            except etree.XMLSyntaxError:
-                msg = "The string provided to create a Dataset from is not valid XML."
-                iati.core.utilities.log_error(msg)
-                raise ValueError(msg)
-            except (AttributeError, TypeError, ValueError):
+                validation_error_log = iati.validator.validate_is_xml(value_stripped_bytes)
+
+                if not validation_error_log.contains_errors():
+                    self.xml_tree = etree.fromstring(value_stripped_bytes)
+                    self._xml_str = value_stripped
+                else:
+                    if validation_error_log.contains_error_of_type(TypeError):
+                        raise TypeError
+                    else:
+                        raise iati.core.exceptions.ValidationError(validation_error_log)
+            except (AttributeError, TypeError):
                 msg = "Datasets can only be ElementTrees or strings containing valid XML, using the xml_tree and xml_str attributes respectively. Actual type: {0}".format(type(value))
                 iati.core.utilities.log_error(msg)
                 raise TypeError(msg)

--- a/iati/core/exceptions.py
+++ b/iati/core/exceptions.py
@@ -28,4 +28,8 @@ class ValidationError(ValueError):
         This is too general to identify many specific problems.
     """
 
-    pass
+    def __init__(self, error_log):
+        """Initialise a ValidationError."""
+        self.error_log = error_log
+
+        super(ValidationError, self).__init__()

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -49,10 +49,10 @@ class TestDatasets(object):
 
     def test_dataset_invalid_xml_string(self):
         """Test Dataset creation with a string that is not valid XML."""
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
 
-        assert 'The string provided to create a Dataset from is not valid XML.' == str(excinfo.value)
+        assert excinfo.value.error_log.contains_error_called('err-not-xml-empty-document')
 
     @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_dataset_number_not_xml(self, not_xml):
@@ -95,10 +95,10 @@ class TestDatasets(object):
         """Test assignment to the xml_str property with an invalid XML string."""
         data = dataset_initialised
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             data.xml_str = iati.core.tests.utilities.XML_STR_INVALID
 
-        assert 'The string provided to create a Dataset from is not valid XML.' == str(excinfo.value)
+        excinfo.value.error_log.contains_error_called('err-not-xml-empty-document')
 
     def test_dataset_xml_str_assignment_tree(self, dataset_initialised):
         """Test assignment to the xml_str property with an ElementTree."""
@@ -156,6 +156,26 @@ class TestDatasets(object):
             data.xml_tree = invalid_value
         assert 'If setting a dataset with the xml_property, an ElementTree should be provided, not a' in str(excinfo.value)
 
+
+class TestDatasetWithEncoding(object):
+    """A container for tests relating to creating a Dataset from various types of input.
+
+    This may be files vs strings, or may revolve around character encoding.
+
+    """
+
+    @pytest.fixture
+    def xml_needing_encoding(self):
+        """An XML string with a placeholder for an encoding through use of `str.format()`"""
+        xml = """<?xml version="1.0" encoding="{}"?>
+        <iati-activities version="xx">
+          <iati-activity>
+             <iati-identifier></iati-identifier>
+         </iati-activity>
+        </iati-activities>"""
+
+        return xml
+
     def test_instantiation_dataset_from_string(self):
         """Test that a dataset instantiated directly from a string (rather than a file) correctly creates an iati.core.data.Dataset and the input data is contained within the object."""
         xml = """<?xml version="1.0"?>
@@ -173,7 +193,7 @@ class TestDatasets(object):
     @pytest.mark.parametrize("encoding", ["UTF-8", "utf-8", "UTF-16", "utf-16",
                                           "ASCII", "ISO-8859-1", "ISO-8859-2",
                                           "BIG5", "EUC-JP"])
-    def test_instantiation_dataset_from_string_with_encoding(self, encoding):
+    def test_instantiation_dataset_from_string_with_encoding(self, xml_needing_encoding, encoding):
         """Test that an encoded dataset instantiated directly from a string (rather than a file) correctly creates an iati.core.data.Dataset and the input data is contained within the object.
 
         Note:
@@ -181,12 +201,7 @@ class TestDatasets(object):
             UTF-32 is deliberately omitted as this causes an error: lxml.etree.XMLSyntaxError: Document is empty
 
         """
-        xml = """<?xml version="1.0" encoding="{}"?>
-        <iati-activities version="xx">
-          <iati-activity>
-             <iati-identifier></iati-identifier>
-         </iati-activity>
-        </iati-activities>""".format(encoding)
+        xml = xml_needing_encoding.format(encoding)
         xml_encoded = xml.encode(encoding)  # Encode the whole string in line with the specified encoding
 
         dataset = iati.core.data.Dataset(xml_encoded)
@@ -197,32 +212,48 @@ class TestDatasets(object):
     @pytest.mark.parametrize("encoding_declared, encoding_used", [
         ("UTF-16", "UTF-8"),
         ("UTF-16", "ISO-8859-1"),
+        ("UTF-16", "ASCII"),
         ("UTF-16", "BIG5"),
-        ("UTF-16", "EUC-JP"),
-        ("ASCII", "UTF-16"),
-        ("ISO-8859-1", "UTF-16"),
-        ("ISO-8859-2", "UTF-16"),
-        ("BIG5", "UTF-16"),
-        ("EUC-JP", "UTF-16")])
-    def test_instantiation_dataset_from_string_with_encoding_mismatch(self, encoding_declared, encoding_used):
+        ("UTF-16", "EUC-JP")
+    ])
+    def test_instantiation_dataset_from_string_with_encoding_mismatch(self, xml_needing_encoding, encoding_declared, encoding_used):
+        """Test that an error is raised when attempting to create a dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
+
+        Todo:
+            Amend error message, when the todo in iati.core.data.Dataset.xml_str() has been resolved.
+
+        Note:
+            There are a number of other errors that may be raised with alternative encoding mismatches. These are not supported since it does not appear likely enough that they will occur and be a large issue in practice.
+
+            This is due to a pair of issues with libxml2 (the underlying library behind lxml):
+
+            1. It only supports a limited number of encodings out-of-the-box.
+            2. Different encoding pairs (whether supported or unsupported by libxml2; byte-equivalent-subsets or distinct encodings; and more), will return different error codes in what one would expect to act as equivalent situations.
+
+        """
+        xml = xml_needing_encoding.format(encoding_declared)
+        xml_encoded = xml.encode(encoding_used)  # Encode the whole string in line with the specified encoding
+
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
+            _ = iati.core.data.Dataset(xml_encoded)
+
+        assert excinfo.value.error_log.contains_error_called('err-encoding-invalid')
+
+    @pytest.mark.parametrize("encoding", ["CP424"])
+    def test_instantiation_dataset_from_string_with_unsupported_encoding(self, xml_needing_encoding, encoding):
         """Test that an error is raised when attempting to create a dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
 
         Todo:
             Amend error message, when the todo in iati.core.data.Dataset.xml_str() has been resolved.
 
         """
-        xml = """<?xml version="1.0" encoding="{}"?>
-        <iati-activities version="xx">
-          <iati-activity>
-             <iati-identifier></iati-identifier>
-         </iati-activity>
-        </iati-activities>""".format(encoding_declared)
-        xml_encoded = xml.encode(encoding_used)  # Encode the whole string in line with the specified encoding
+        xml = xml_needing_encoding.format(encoding)
+        xml_encoded = xml.encode(encoding)  # Encode the whole string in line with the specified encoding
 
-        with pytest.raises(ValueError) as excinfo:
-            dataset = iati.core.data.Dataset(xml_encoded)
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
+            _ = iati.core.data.Dataset(xml_encoded)
 
-        assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
+        assert excinfo.value.error_log.contains_error_called('err-encoding-unsupported')
 
 
 class TestDatasetSourceFinding(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -258,12 +258,21 @@ class TestValidateIsXML(object):
 
         assert iati.validator.is_xml(data)
 
-    @pytest.mark.skip
     def test_xml_check_valid_xml_detailed_output(self, xml_str):
         """Perform check to see whether a parameter is valid XML. The parameter is valid XML.
         Obtain detailed error output.
         """
         result = iati.validator.validate_is_xml(xml_str)
+
+        assert len(result) == 0
+
+    def test_xml_check_valid_xml_in_dataset_detailed_output(self, xml_str):
+        """Perform check to see whether a Dataset is valid XML.
+        Obtain detailed error output.
+        """
+        data = iati.core.Dataset(xml_str)
+
+        result = iati.validator.validate_is_xml(data)
 
         assert len(result) == 0
 
@@ -276,18 +285,6 @@ class TestValidateIsXML(object):
 
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-not-string')
-
-    @pytest.mark.skip
-    def test_xml_check_valid_xml_in_dataset_detailed_output(self, xml_str):
-        """Perform check to see whether a Dataset is valid XML.
-        Obtain detailed error output.
-        """
-        data = iati.core.Dataset(xml_str)
-
-        result = iati.validator.validate_is_xml(data)
-
-        assert len(result) == 0
-
 
 
 class ValidateCodelistsBase(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -238,12 +238,18 @@ class TestValidation(object):
 
     def test_error_code_attributes(self):
         """Check that error codes have the required attributes."""
-        expected_attributes = ['category', 'description', 'info', 'help']
+        expected_attributes = [
+            ('base_exception', type),
+            ('category', str),
+            ('description', str),
+            ('info', str),
+            ('help', str)
+        ]
         for err_code_name, err_code in iati.validator._ERROR_CODES.items():
             code_attrs = err_code.keys()
-            for attr in expected_attributes:
-                assert attr in code_attrs
-                assert isinstance(err_code[attr], str)
+            for (attr_name, attr_type) in expected_attributes:
+                assert attr_name in code_attrs
+                assert isinstance(err_code[attr_name], attr_type)
 
 
 class TestValidateIsXML(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -375,6 +375,7 @@ class TestValidateIsXML(object):
 
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-content-at-end')
+        assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
 
 
 class ValidateCodelistsBase(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -284,20 +284,6 @@ class TestValidateIsXML(object):
 
         assert len(result) == 0
 
-    @pytest.mark.skip
-    def test_xml_check_valid_xml_comments_before_detailed_output(self, xml_str, str_not_xml):
-        """Perform check to see whether a parameter is valid XML. The parameter is valid XML.
-
-        There is a comment added before the XML.
-        Obtain detailed error output.
-        """
-        comment = '<!-- ' + str_not_xml + ' -->'
-        xml_with_comments = comment + xml_str
-
-        result = iati.validator.validate_is_xml(xml_with_comments)
-
-        assert len(result) == 0
-
     def test_xml_check_valid_xml_in_dataset_detailed_output(self, xml_str):
         """Perform check to see whether a Dataset is valid XML.
         Obtain detailed error output.
@@ -338,6 +324,20 @@ class TestValidateIsXML(object):
 
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-empty-document')
+
+    def test_xml_check_not_xml_str_comments_before(self, xml_str, str_not_xml):
+        """Perform check to locate the XML Syntax Errors in a string.
+
+        There is a comment added before the XML.
+        Obtain detailed error output.
+        """
+        comment = '<!-- ' + str_not_xml + ' -->'
+        not_xml = comment + xml_str
+
+        result = iati.validator.validate_is_xml(not_xml)
+
+        assert result.contains_errors()
+        assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
 
     def test_xml_check_not_xml_str_text_after_xml(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -239,6 +239,11 @@ class TestValidateIsXML(object):
         """A valid XML string."""
         return request.param
 
+    @pytest.fixture
+    def xml_str_no_prolog(self, xml_str):
+        """A valid XML string with the prolog removed."""
+        return '\n'.join(xml_str.strip().split('\n')[1:])
+
     @pytest.fixture(params=iati.core.tests.utilities.find_parameter_by_type(['str'], False) + [iati.core.tests.utilities.XML_STR_INVALID])
     def not_xml(self, request):
         """A value that is not a valid XML string."""
@@ -272,8 +277,9 @@ class TestValidateIsXML(object):
         assert len(result) == 0
 
     def test_xml_check_valid_xml_comments_after_detailed_output(self, xml_str, str_not_xml):
-        """Perform check to see whether a parameter is valid XML. The parameter is valid XML.
+        """Perform check to see string a parameter is valid XML.
 
+        The string is valid XML.
         There is a comment added after the XML.
         Obtain detailed error output.
         """
@@ -284,14 +290,15 @@ class TestValidateIsXML(object):
 
         assert len(result) == 0
 
-    def test_xml_check_valid_xml_str_comments_before_no_prolog(self, xml_str, str_not_xml):
-        """Perform check to see whether a parameter is valid XML. The parameter is valid XML.
+    def test_xml_check_valid_xml_str_comments_before_no_prolog_detailed_output(self, xml_str_no_prolog, str_not_xml):
+        """Perform check to see whether a string is valid XML.
 
-        There is a comment added before the XML. There is no XMl prolog.
+        The string is valid XML.
+        There is a comment added before the XML. There is no XML prolog.
         Obtain detailed error output.
         """
         comment = '<!-- ' + str_not_xml + ' -->'
-        xml_prefixed_with_comment = comment + '\n'.join(xml_str.strip().split('\n')[1:])
+        xml_prefixed_with_comment = comment + xml_str_no_prolog
 
         result = iati.validator.validate_is_xml(xml_prefixed_with_comment)
 
@@ -299,6 +306,7 @@ class TestValidateIsXML(object):
 
     def test_xml_check_valid_xml_in_dataset_detailed_output(self, xml_str):
         """Perform check to see whether a Dataset is valid XML.
+
         Obtain detailed error output.
         """
         data = iati.core.Dataset(xml_str)
@@ -310,6 +318,7 @@ class TestValidateIsXML(object):
     @pytest.mark.parametrize("not_str", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_xml_check_not_str_detailed_output(self, not_str):
         """Perform check to see whether a parameter is valid XML. The parameter is not valid XML.
+
         Obtain detailed error output.
         """
         result = iati.validator.validate_is_xml(not_str)
@@ -319,7 +328,9 @@ class TestValidateIsXML(object):
 
     def test_xml_check_not_xml_str_no_start_tag_detailed_output(self, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
+
         The string has no XML start tag.
+        Obtain detailed error output.
         """
         result = iati.validator.validate_is_xml(str_not_xml)
 
@@ -330,6 +341,7 @@ class TestValidateIsXML(object):
         """Perform check to locate the XML Syntax Errors in a string.
 
         The string has non-XML text before the XML starts.
+        Obtain detailed error output.
         """
         not_xml = str_not_xml + xml_str
 
@@ -356,6 +368,7 @@ class TestValidateIsXML(object):
         """Perform check to locate the XML Syntax Errors in a string.
 
         The string has non-XML text before the XML starts.
+        Obtain detailed error output.
         """
         not_xml = xml_str + str_not_xml
 
@@ -367,7 +380,8 @@ class TestValidateIsXML(object):
     def test_xml_check_not_xml_str_xml_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        The string is two concatenated XML filed.
+        The string is two concatenated XML strings. Each contains a prolog.
+        Obtain detailed error output.
         """
         not_xml = xml_str + xml_str
 

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -706,6 +706,7 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
         result = iati.validator.full_validation(data, schema_version)[0]
 
         assert isinstance(result, iati.validator.ValidationError)
+        assert result.name == 'err-code-not-on-codelist'
         assert result.status == 'error'
         assert result.line_number == 3
         assert result.context == '\n'.join(xml_str.split('\n')[1:4])
@@ -731,6 +732,7 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
 
         result = iati.validator.full_validation(data, schema_incomplete_codelist)[0]
 
+        assert result.name == 'warn-code-not-on-codelist'
         assert result.line_number == 18
         assert result.context == '\n'.join(xml_str.split('\n')[16:19])
         assert result.status == 'warning'

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -28,6 +28,7 @@ class TestValidationError(object):
         err_detail = iati.validator._ERROR_CODES[err_name]
 
         assert isinstance(err, iati.validator.ValidationError)
+        assert err.name == err_name
         assert err.category == err_detail['category']
         assert err.description == err_detail['description']
         assert err.info == err_detail['info']
@@ -38,15 +39,23 @@ class TestValidationErrorLog(object):
     """A container for tests relating to Validation Error Logs."""
 
     @pytest.fixture
-    def error(self):
+    def err_name(self):
+        """The name of an error."""
+        return 'err-code-not-on-codelist'
+
+    @pytest.fixture
+    def error(self, err_name):
         """An error."""
-        err_name = 'err-code-not-on-codelist'
         return iati.validator.ValidationError(err_name)
 
     @pytest.fixture
-    def warning(self):
+    def warning_name(self):
+        """The name of a warning."""
+        return 'warn-code-not-on-codelist'
+
+    @pytest.fixture
+    def warning(self, warning_name):
         """A warning."""
-        warning_name = 'warn-code-not-on-codelist'
         return iati.validator.ValidationError(warning_name)
 
     @pytest.fixture
@@ -86,23 +95,29 @@ class TestValidationErrorLog(object):
         assert not error_log.contains_errors()
         assert not error_log.contains_warnings()
 
-    def test_error_log_add_errors(self, error_log_with_error):
+    def test_error_log_add_errors(self, error_log_with_error, err_name, warning_name):
         """Test that errors are identified as errors when added to the error log."""
         assert len(error_log_with_error) == 1
         assert error_log_with_error.contains_errors()
         assert not error_log_with_error.contains_warnings()
+        assert error_log_with_error.contains_error_called(err_name)
+        assert not error_log_with_error.contains_error_called(warning_name)
 
-    def test_error_log_add_warnings(self, error_log_with_warning):
+    def test_error_log_add_warnings(self, error_log_with_warning, err_name, warning_name):
         """Test that warnings are not identified as errors when added to the error log."""
         assert len(error_log_with_warning) == 1
         assert not error_log_with_warning.contains_errors()
         assert error_log_with_warning.contains_warnings()
+        assert not error_log_with_warning.contains_error_called(err_name)
+        assert error_log_with_warning.contains_error_called(warning_name)
 
-    def test_error_log_add_mixed(self, error_log_mixed_contents):
+    def test_error_log_add_mixed(self, error_log_mixed_contents, err_name, warning_name):
         """Test that a mix of errors and warnings are identified as such when added to the error log."""
         assert len(error_log_mixed_contents) == 2
         assert error_log_mixed_contents.contains_errors()
         assert error_log_mixed_contents.contains_warnings()
+        assert error_log_mixed_contents.contains_error_called(err_name)
+        assert error_log_mixed_contents.contains_error_called(warning_name)
 
     @pytest.mark.parametrize("not_ValidationError", iati.core.tests.utilities.find_parameter_by_type([], False))
     def test_error_log_add_incorrect_type(self, error_log, not_ValidationError):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -174,23 +174,6 @@ class TestValidationErrorLog(object):
 class TestValidation(object):
     """A container for tests relating to validation."""
 
-    @pytest.mark.parametrize("xml", [iati.core.tests.utilities.XML_STR_VALID_NOT_IATI, iati.core.tests.utilities.XML_STR_VALID_IATI, iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE, iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE])
-    def test_xml_check_valid_xml(self, xml):
-        """Perform check to see whether a parameter is valid XML. The parameter is valid XML."""
-        assert iati.validator.is_xml(xml)
-
-    @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False) + [iati.core.tests.utilities.XML_STR_INVALID])
-    def test_xml_check_not_xml(self, not_xml):
-        """Perform check to see whether a parameter is valid XML. The parameter is not valid XML."""
-        assert not iati.validator.is_xml(not_xml)
-
-    @pytest.mark.parametrize("xml", [iati.core.tests.utilities.XML_STR_VALID_NOT_IATI, iati.core.tests.utilities.XML_STR_VALID_IATI, iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE, iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE])
-    def test_xml_check_valid_xml_in_dataset(self, xml):
-        """Perform check to see whether a Dataset is deemed valid XML."""
-        data = iati.core.Dataset(xml)
-
-        assert iati.validator.is_xml(data)
-
     def test_basic_validation_valid(self):
         """Perform a super simple data validation against a valid Dataset."""
         data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
@@ -240,6 +223,71 @@ class TestValidation(object):
             for attr in expected_attributes:
                 assert attr in code_attrs
                 assert isinstance(err_code[attr], str)
+
+
+class TestValidateIsXML(object):
+    """A container for tests checking whether a value is valid XML."""
+
+
+    @pytest.fixture(params=[
+        iati.core.tests.utilities.XML_STR_VALID_NOT_IATI,
+        iati.core.tests.utilities.XML_STR_VALID_IATI,
+        iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE,
+        iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE
+    ])
+    def xml_str(self, request):
+        """A valid XML string."""
+        return request.param
+
+    @pytest.fixture(params=iati.core.tests.utilities.find_parameter_by_type(['str'], False) + [iati.core.tests.utilities.XML_STR_INVALID])
+    def not_xml(self, request):
+        """Not a valid XML string."""
+        return request.param
+
+    def test_xml_check_valid_xml(self, xml_str):
+        """Perform check to see whether a parameter is valid XML. The parameter is valid XML."""
+        assert iati.validator.is_xml(xml_str)
+
+    def test_xml_check_not_xml(self, not_xml):
+        """Perform check to see whether a parameter is valid XML. The parameter is not valid XML."""
+        assert not iati.validator.is_xml(not_xml)
+
+    def test_xml_check_valid_xml_in_dataset(self, xml_str):
+        """Perform check to see whether a Dataset is deemed valid XML."""
+        data = iati.core.Dataset(xml_str)
+
+        assert iati.validator.is_xml(data)
+
+    @pytest.mark.skip
+    def test_xml_check_valid_xml_detailed_output(self, xml_str):
+        """Perform check to see whether a parameter is valid XML. The parameter is valid XML.
+        Obtain detailed error output.
+        """
+        result = iati.validator.validate_is_xml(xml_str)
+
+        assert len(result) == 0
+
+    @pytest.mark.parametrize("not_str", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    def test_xml_check_not_xml(self, not_str):
+        """Perform check to see whether a parameter is valid XML. The parameter is not valid XML.
+        Obtain detailed error output.
+        """
+        result = iati.validator.validate_is_xml(not_str)
+
+        assert result.contains_errors()
+        assert result.contains_error_called('err-not-xml-not-string')
+
+    @pytest.mark.skip
+    def test_xml_check_valid_xml_in_dataset_detailed_output(self, xml_str):
+        """Perform check to see whether a Dataset is valid XML.
+        Obtain detailed error output.
+        """
+        data = iati.core.Dataset(xml_str)
+
+        result = iati.validator.validate_is_xml(data)
+
+        assert len(result) == 0
+
 
 
 class ValidateCodelistsBase(object):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -373,6 +373,7 @@ class TestValidateIsXML(object):
 
         result = iati.validator.validate_is_xml(not_xml)
 
+        assert len(result) == 2
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-content-at-end')
         assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -412,6 +412,16 @@ class ValidateCodelistsBase(object):
 
 
     @pytest.fixture
+    def schema_basic(self):
+        """A schema with no Codelists added.
+
+        Returns:
+            A valid activity schema with no Codelists added.
+
+        """
+        return iati.core.Schema(name=iati.core.tests.utilities.SCHEMA_NAME_VALID)
+
+    @pytest.fixture
     def schema_version(self):
         """A schema with the Version Codelist added.
 
@@ -679,7 +689,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         assert iati.validator.is_valid(data, schema_sectors)
 
 
-class TestValidatorDetailedOutput(ValidateCodelistsBase):
+class TestValidatorFullValidation(ValidateCodelistsBase):
     """A container for tests relating to detailed error output from validation."""
 
     def test_basic_validation_codelist_valid_detailed_output(self, schema_version):
@@ -726,3 +736,12 @@ class TestValidatorDetailedOutput(ValidateCodelistsBase):
         assert result.status == 'warning'
         assert 'Country' in result.info
         assert 'Country' in result.help
+
+    def test_basic_validation_not_xml_detailed_output(self, schema_basic):
+        """Perform full validation against a string that is not XML."""
+        not_xml = 'This is not XML.'
+
+        result = iati.validator.full_validation(not_xml, schema_basic)
+
+        assert len(result) == 1
+        assert result.contains_error_called('err-not-xml-empty-document')

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -392,6 +392,20 @@ class TestValidateIsXML(object):
         assert result.contains_error_called('err-not-xml-content-at-end')
         assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
 
+    def test_xml_check_not_xml_str_xml_after_xml_no_prolog_detailed_output(self, xml_str_no_prolog, str_not_xml):
+        """Perform check to locate the XML Syntax Errors in a string.
+
+        The string is two concatenated XML strings. Each contains a prolog.
+        Obtain detailed error output.
+        """
+        not_xml = xml_str_no_prolog + xml_str_no_prolog
+
+        result = iati.validator.validate_is_xml(not_xml)
+
+        assert len(result) == 1
+        assert result.contains_errors()
+        assert result.contains_error_called('err-not-xml-content-at-end')
+
 
 class ValidateCodelistsBase(object):
     """A container for fixtures required for Codelist validation tests."""

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -284,6 +284,19 @@ class TestValidateIsXML(object):
 
         assert len(result) == 0
 
+    def test_xml_check_valid_xml_str_comments_before_no_prolog(self, xml_str, str_not_xml):
+        """Perform check to see whether a parameter is valid XML. The parameter is valid XML.
+
+        There is a comment added before the XML. There is no XMl prolog.
+        Obtain detailed error output.
+        """
+        comment = '<!-- ' + str_not_xml + ' -->'
+        xml_prefixed_with_comment = comment + '\n'.join(xml_str.strip().split('\n')[1:])
+
+        result = iati.validator.validate_is_xml(xml_prefixed_with_comment)
+
+        assert len(result) == 0
+
     def test_xml_check_valid_xml_in_dataset_detailed_output(self, xml_str):
         """Perform check to see whether a Dataset is valid XML.
         Obtain detailed error output.
@@ -328,7 +341,7 @@ class TestValidateIsXML(object):
     def test_xml_check_not_xml_str_comments_before(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        There is a comment added before the XML.
+        There is a comment added before the XML. The XML contains a prolog.
         Obtain detailed error output.
         """
         comment = '<!-- ' + str_not_xml + ' -->'

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -29,6 +29,7 @@ class TestValidationError(object):
 
         assert isinstance(err, iati.validator.ValidationError)
         assert err.name == err_name
+        assert err.base_exception == ValueError
         assert err.category == err_detail['category']
         assert err.description == err_detail['description']
         assert err.info == err_detail['info']
@@ -44,6 +45,11 @@ class TestValidationErrorLog(object):
         return 'err-code-not-on-codelist'
 
     @pytest.fixture
+    def err_type(self, err_name):
+        """The type of an error."""
+        return iati.validator._ERROR_CODES[err_name]['base_exception']
+
+    @pytest.fixture
     def error(self, err_name):
         """An error."""
         return iati.validator.ValidationError(err_name)
@@ -52,6 +58,16 @@ class TestValidationErrorLog(object):
     def warning_name(self):
         """The name of a warning."""
         return 'warn-code-not-on-codelist'
+
+    @pytest.fixture
+    def warning_type(self, warning_name):
+        """The type of an error."""
+        return iati.validator._ERROR_CODES[warning_name]['base_exception']
+
+    @pytest.fixture
+    def unused_exception_type(self):
+        """An exception type that is not covered by the ValidationErrors."""
+        return MemoryError
 
     @pytest.fixture
     def warning(self, warning_name):
@@ -95,29 +111,34 @@ class TestValidationErrorLog(object):
         assert not error_log.contains_errors()
         assert not error_log.contains_warnings()
 
-    def test_error_log_add_errors(self, error_log_with_error, err_name, warning_name):
+    def test_error_log_add_errors(self, error_log_with_error, err_name, warning_name, err_type):
         """Test that errors are identified as errors when added to the error log."""
         assert len(error_log_with_error) == 1
         assert error_log_with_error.contains_errors()
         assert not error_log_with_error.contains_warnings()
         assert error_log_with_error.contains_error_called(err_name)
         assert not error_log_with_error.contains_error_called(warning_name)
+        assert error_log_with_error.contains_error_of_type(err_type)
 
-    def test_error_log_add_warnings(self, error_log_with_warning, err_name, warning_name):
+    def test_error_log_add_warnings(self, error_log_with_warning, err_name, warning_name, warning_type):
         """Test that warnings are not identified as errors when added to the error log."""
         assert len(error_log_with_warning) == 1
         assert not error_log_with_warning.contains_errors()
         assert error_log_with_warning.contains_warnings()
         assert not error_log_with_warning.contains_error_called(err_name)
         assert error_log_with_warning.contains_error_called(warning_name)
+        assert error_log_with_warning.contains_error_of_type(warning_type)
 
-    def test_error_log_add_mixed(self, error_log_mixed_contents, err_name, warning_name):
+    def test_error_log_add_mixed(self, error_log_mixed_contents, err_name, warning_name, err_type, warning_type, unused_exception_type):
         """Test that a mix of errors and warnings are identified as such when added to the error log."""
         assert len(error_log_mixed_contents) == 2
         assert error_log_mixed_contents.contains_errors()
         assert error_log_mixed_contents.contains_warnings()
         assert error_log_mixed_contents.contains_error_called(err_name)
         assert error_log_mixed_contents.contains_error_called(warning_name)
+        assert error_log_mixed_contents.contains_error_of_type(err_type)
+        assert error_log_mixed_contents.contains_error_of_type(warning_type)
+        assert not error_log_mixed_contents.contains_error_of_type(unused_exception_type)
 
     @pytest.mark.parametrize("not_ValidationError", iati.core.tests.utilities.find_parameter_by_type([], False))
     def test_error_log_add_incorrect_type(self, error_log, not_ValidationError):

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -277,7 +277,7 @@ class TestValidateIsXML(object):
         assert len(result) == 0
 
     @pytest.mark.parametrize("not_str", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
-    def test_xml_check_not_xml(self, not_str):
+    def test_xml_check_not_str_detailed_output(self, not_str):
         """Perform check to see whether a parameter is valid XML. The parameter is not valid XML.
         Obtain detailed error output.
         """

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -286,6 +286,17 @@ class TestValidateIsXML(object):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-not-string')
 
+    def test_xml_check_not_xml_str_no_opening_tag(self):
+        """Perform check to locate the XML Syntax Errors in a string.
+        The string has no XML opening tag.
+        """
+        not_xml = 'This is not XML.'
+
+        result = iati.validator.validate_is_xml(not_xml)
+
+        assert result.contains_errors()
+        assert result.contains_error_called('err-not-xml-empty-document')
+
 
 class ValidateCodelistsBase(object):
     """A container for fixtures required for Codelist validation tests."""

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -317,7 +317,7 @@ class TestValidateIsXML(object):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-not-string')
 
-    def test_xml_check_not_xml_str_no_start_tag(self, str_not_xml):
+    def test_xml_check_not_xml_str_no_start_tag_detailed_output(self, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
         The string has no XML start tag.
         """
@@ -326,7 +326,7 @@ class TestValidateIsXML(object):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-empty-document')
 
-    def test_xml_check_not_xml_str_text_before_xml(self, str_not_xml, xml_str):
+    def test_xml_check_not_xml_str_text_before_xml_detailed_output(self, str_not_xml, xml_str):
         """Perform check to locate the XML Syntax Errors in a string.
 
         The string has non-XML text before the XML starts.
@@ -338,7 +338,7 @@ class TestValidateIsXML(object):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-empty-document')
 
-    def test_xml_check_not_xml_str_comments_before(self, xml_str, str_not_xml):
+    def test_xml_check_not_xml_str_comments_before_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
         There is a comment added before the XML. The XML contains a prolog.
@@ -352,7 +352,7 @@ class TestValidateIsXML(object):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
 
-    def test_xml_check_not_xml_str_text_after_xml(self, xml_str, str_not_xml):
+    def test_xml_check_not_xml_str_text_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
         The string has non-XML text before the XML starts.
@@ -364,7 +364,7 @@ class TestValidateIsXML(object):
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-content-at-end')
 
-    def test_xml_check_not_xml_str_xml_after_xml(self, xml_str, str_not_xml):
+    def test_xml_check_not_xml_str_xml_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
         The string is two concatenated XML filed.

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -267,8 +267,8 @@ class TestValidateIsXML(object):
         return request.param
 
     @pytest.fixture
-    def xml_str_no_prolog(self, xml_str):
-        """A valid XML string with the prolog removed."""
+    def xml_str_no_text_decl(self, xml_str):
+        """A valid XML string with the text declaration removed."""
         return '\n'.join(xml_str.strip().split('\n')[1:])
 
     @pytest.fixture(params=iati.core.tests.utilities.find_parameter_by_type(['str'], False) + [iati.core.tests.utilities.XML_STR_INVALID])
@@ -317,15 +317,15 @@ class TestValidateIsXML(object):
 
         assert len(result) == 0
 
-    def test_xml_check_valid_xml_str_comments_before_no_prolog_detailed_output(self, xml_str_no_prolog, str_not_xml):
+    def test_xml_check_valid_xml_str_comments_before_no_text_decl_detailed_output(self, xml_str_no_text_decl, str_not_xml):
         """Perform check to see whether a string is valid XML.
 
         The string is valid XML.
-        There is a comment added before the XML. There is no XML prolog.
+        There is a comment added before the XML. There is no XML text declaration.
         Obtain detailed error output.
         """
         comment = '<!-- ' + str_not_xml + ' -->'
-        xml_prefixed_with_comment = comment + xml_str_no_prolog
+        xml_prefixed_with_comment = comment + xml_str_no_text_decl
 
         result = iati.validator.validate_is_xml(xml_prefixed_with_comment)
 
@@ -380,7 +380,7 @@ class TestValidateIsXML(object):
     def test_xml_check_not_xml_str_comments_before_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        There is a comment added before the XML. The XML contains a prolog.
+        There is a comment added before the XML. The XML contains a text declaration.
         Obtain detailed error output.
         """
         comment = '<!-- ' + str_not_xml + ' -->'
@@ -389,7 +389,7 @@ class TestValidateIsXML(object):
         result = iati.validator.validate_is_xml(not_xml)
 
         assert result.contains_errors()
-        assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
+        assert result.contains_error_called('err-not-xml-xml-text-decl-only-at-doc-start')
 
     def test_xml_check_not_xml_str_text_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
@@ -407,7 +407,7 @@ class TestValidateIsXML(object):
     def test_xml_check_not_xml_str_xml_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        The string is two concatenated XML strings. Each contains a prolog.
+        The string is two concatenated XML strings. Each contains a text declaration.
         Obtain detailed error output.
         """
         not_xml = xml_str + xml_str
@@ -417,15 +417,15 @@ class TestValidateIsXML(object):
         assert len(result) == 2
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-content-at-end')
-        assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
+        assert result.contains_error_called('err-not-xml-xml-text-decl-only-at-doc-start')
 
-    def test_xml_check_not_xml_str_xml_after_xml_no_prolog_detailed_output(self, xml_str_no_prolog, str_not_xml):
+    def test_xml_check_not_xml_str_xml_after_xml_no_text_decl_detailed_output(self, xml_str_no_text_decl, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        The string is two concatenated XML strings. Each contains a prolog.
+        The string is two concatenated XML strings. Each contains a text declaration.
         Obtain detailed error output.
         """
-        not_xml = xml_str_no_prolog + xml_str_no_prolog
+        not_xml = xml_str_no_text_decl + xml_str_no_text_decl
 
         result = iati.validator.validate_is_xml(not_xml)
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -118,6 +118,20 @@ class ValidationErrorLog(object):
 
         return len(errors_with_name) > 0
 
+    def contains_error_of_type(self, err_type):
+        """Check the log for an error or warning with the specified base exception type.
+
+        Args:
+            err_type (type): The type of the error to look for.
+
+        Returns:
+            bool: Whether there is an error or warning with the specified type within the log.
+
+        """
+        errors_with_type = [err for err in self._values if err.base_exception == err_type]
+
+        return len(errors_with_type) > 0
+
 
     def extend(self, values):
         """Extend the ErrorLog with ValidationErrors from an iterable.
@@ -167,42 +181,49 @@ class ValidationErrorLog(object):
 
 _ERROR_CODES = {
     'err-code-not-on-codelist': {
+        'base_exception': ValueError,
         'category': 'codelist',
         'description': 'An attribute that requires a Code from a particular complete Codelist contained a value not on the Codelist.',
         'info': '{code} is not a valid Code on the {codelist.name} Codelist.',
         'help': 'The `{attr_name}` attribute must contain a value on the `{codelist.name}` Codelist.\nSee http://iatistandard.org/202/codelists/{codelist.name} for permitted values.'
     },
     'warn-code-not-on-codelist': {
+        'base_exception': Warning,
         'category': 'codelist',
         'description': 'An attribute that should contain a Code from a particular incomplete Codelist contained a value not on the Codelist.',
         'info': '{code} is not a Code on the {codelist.name} Codelist. ',
         'help': 'The `{attr_name}` attribute should contain a value on the `{codelist.name}` Codelist. Note that values not on the Codelist may be valid in particular circumstances.\nSee http://iatistandard.org/202/codelists/{codelist.name} for values on the Codelist.'
     },
     'err-not-xml-not-string': {
+        'base_exception': TypeError,
         'category': 'xml',
         'description': 'A variable that is not a string cannot be XML.',
         'info': 'The value provided is a `{problem_var_type}` rather than a `str`.',
         'help': 'A string is a series of characters (letters, numbers, punctuation, etc). For more information about what these are, see https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str'
     },
     'err-not-xml-uncategorised-xml-syntax-error': {
+        'base_exception': Exception,
         'category': 'xml',
         'description': 'An uncategorised syntax error occurred when parsing the XML.',
         'info': '{err}',
         'help': 'There are many different ways in which a file may not be valid XML. The most common of these have had specific error messages created. This is not currently one of them.\nShould it be identified that this error occurs frequently, a specific error message will be created.\nFor an introduction to XML see https://www.w3schools.com/Xml/'
     },
     'err-not-xml-content-at-end': {
+        'base_exception': ValueError,
         'category': 'xml',
         'description': 'An XML file must contain no information after the XML has finished.',
         'info': '{err}',
         'help': 'An XML document contains a number of elements that are started and ended using tags. The XML is deemed finished once the number of start tags and the number of end tags is the same.\nThe contents of the data after this point does not matter - it may be valid XML on its own, or may have no meaning.\nShould it be required that additional information be in the document, XML comments may be used. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
     },
     'err-not-xml-empty-document': {
+        'base_exception': ValueError,
         'category': 'xml',
         'description': 'An XML file must start with the XML start tag. The XML start tag is `<`.',
         'info': '{err}',
         'help': 'An XML document must contain only valid XML.\nShould it be required that additional information be in the document, XML comments may be used. Comments may not, however, be right at the very start of the document. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
     },
     'err-not-xml-xml-prolog-only-at-doc-start': {
+        'base_exception': ValueError,
         'category': 'xml',
         'description': 'The XML prolog must occur at the start of the document.',
         'info': '{err}',

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -222,12 +222,26 @@ _ERROR_CODES = {
         'info': '{err}',
         'help': 'An XML document must contain only valid XML.\nShould it be required that additional information be in the document, XML comments may be used. Comments may not, however, be right at the very start of the document. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
     },
-    'err-not-xml-xml-prolog-only-at-doc-start': {
+    'err-not-xml-xml-text-decl-only-at-doc-start': {
         'base_exception': ValueError,
         'category': 'xml',
-        'description': 'The XML prolog must occur at the start of the document.',
+        'description': 'The XML text declaration must occur at the start of the document.',
         'info': '{err}',
-        'help': 'The XML prolog specifies how a computer must read the rest of the XML file. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nIt looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`.\nFor more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
+        'help': 'The XML text declaration specifies how a computer must read the rest of the XML file. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nIt looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`.\nFor more information about the XML text declaration, see https://www.w3schools.com/xml/xml_syntax.asp and https://www.w3.org/TR/2000/REC-xml-20001006#sec-TextDecl'
+    },
+    'err-encoding-invalid': {
+        'base_exception': ValueError,
+        'category': 'file',
+        'description': 'The encoding specified within the XML text declaration is different from the actual encoding of the XML file.',
+        'info': '{err}',
+        'help': 'The encoding of a file specifies how a computer should interpret the 1s and 0s that it is made up of. For more information about encoding, see https://www.w3.org/International/questions/qa-what-is-encoding\nThe XML text declaration looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`. For more information about the XML text declaration, see https://www.w3schools.com/xml/xml_syntax.asp and https://www.w3.org/TR/2000/REC-xml-20001006#sec-TextDecl'
+    },
+    'err-encoding-unsupported': {
+        'base_exception': ValueError,
+        'category': 'file',
+        'description': 'The encoding of the XML file is not supported by a tool used by IATI.',
+        'info': '{err}',
+        'help': 'The encoding of a file specifies how a computer should interpret the 1s and 0s that it is made up of. For more information about encoding, see https://www.w3.org/International/questions/qa-what-is-encoding'
     }
 }
 
@@ -368,7 +382,9 @@ def _parse_xml_syntax_error(err):
     lxml_to_iati_error_mapping = {
         'ERR_DOCUMENT_EMPTY': 'err-not-xml-empty-document',
         'ERR_DOCUMENT_END': 'err-not-xml-content-at-end',
-        'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-prolog-only-at-doc-start'
+        'ERR_INVALID_ENCODING': 'err-encoding-invalid',
+        'ERR_UNSUPPORTED_ENCODING': 'err-encoding-unsupported',
+        'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-text-decl-only-at-doc-start'
     }
 
     try:

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -272,8 +272,6 @@ def _check_is_xml(maybe_xml):
         problem_var_type = type(maybe_xml)
         error = ValidationError('err-not-xml-not-string', locals())
         error_log.add(error)
-    except ValueError as err:
-        return False
 
     return error_log
 
@@ -390,7 +388,6 @@ def is_xml(maybe_xml):
         return not error_log.contains_errors()
     else:
         return error_log
-
 
 
 def validate_is_xml(dataset):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -256,6 +256,7 @@ def _check_is_xml(maybe_xml):
 
     Returns:
         iati.validator.ValidationErrorLog: A log of the errors that occurred.
+
     """
     error_log = ValidationErrorLog()
 
@@ -389,4 +390,18 @@ def is_xml(maybe_xml):
         return not error_log.contains_errors()
     else:
         return error_log
+
+
+
+def validate_is_xml(dataset):
+    """Check whether a Dataset contains valid XML.
+
+    Args:
+        dataset (iati.core.Dataset): The Dataset to check validity of.
+
+    Returns:
+        iati.validator.ValidationErrorLog: A log of the errors that occurred.
+
+    """
+    return _check_is_xml(dataset)
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -377,7 +377,12 @@ def full_validation(dataset, schema):
         Create test against a bad Schema.
 
     """
-    return _check_codelist_values(dataset, schema)
+    error_log = ValidationErrorLog()
+
+    error_log.extend(_check_is_xml(dataset))
+    error_log.extend(_check_codelist_values(dataset, schema))
+
+    return error_log
 
 
 def is_iati_xml(dataset, schema):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -304,7 +304,7 @@ def full_validation(dataset, schema):
         Parameters are likely to change in some manner.
 
     Returns:
-        list of dict: A list of dictionaries containing error output. An empty list indicates that there are no errors.
+        iati.validator.ValidationErrorLog: A log of the errors that occurred.
 
     Todo:
         Create test against a bad Schema.

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -297,7 +297,7 @@ def _check_is_xml(maybe_xml):
     try:
         _ = etree.fromstring(maybe_xml.strip())
     except etree.XMLSyntaxError as parse_errors:
-        import pdb;pdb.set_trace()
+        # import pdb;pdb.set_trace()
         for err in parse_errors.error_log:
             error = _parse_xml_syntax_error(err)
             error_log.add(error)

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -326,11 +326,17 @@ def _parse_xml_syntax_error(err):
     line_number = err.line
     column_number = err.column
 
-    # create the error
-    if err.type_name == 'ERR_DOCUMENT_EMPTY':
-        error = ValidationError('err-not-xml-empty-document', locals())
-    else:
-        error = ValidationError('err-not-xml-uncategorised-xml-syntax-error', locals())
+    # undertake the mapping between error name formats
+    lxml_to_iati_error_mapping = {
+        'ERR_DOCUMENT_EMPTY': 'err-not-xml-empty-document'
+    }
+
+    try:
+        err_name = lxml_to_iati_error_mapping[err.type_name]
+    except KeyError:
+        err_name = 'err-not-xml-uncategorised-xml-syntax-error'
+
+    error = ValidationError(err_name, locals())
 
     return error
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -486,7 +486,7 @@ def is_xml(maybe_xml):
     """Determine whether a given parameter is XML.
 
     Args:
-        maybe_xml (str): An string that may or may not contain valid XML.
+        maybe_xml (str): An string that may or may not be valid XML.
 
     Returns:
         bool: A boolean indicating whether the given Dataset is valid XML.
@@ -497,15 +497,15 @@ def is_xml(maybe_xml):
     return not error_log.contains_errors()
 
 
-def validate_is_xml(dataset):
+def validate_is_xml(maybe_xml):
     """Check whether a Dataset contains valid XML.
 
     Args:
-        dataset (iati.core.Dataset): The Dataset to check validity of.
+        maybe_xml (str): An string that may or may not be valid XML.
 
     Returns:
         iati.validator.ValidationErrorLog: A log of the errors that occurred.
 
     """
-    return _check_is_xml(dataset)
+    return _check_is_xml(maybe_xml)
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -265,7 +265,6 @@ def _check_is_xml(maybe_xml):
 
     try:
         _ = etree.fromstring(maybe_xml.strip())
-        return True
     except etree.XMLSyntaxError as err:
         return False
     except (AttributeError, TypeError, ValueError):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -206,7 +206,7 @@ _ERROR_CODES = {
         'category': 'xml',
         'description': 'The XML prolog must occur at the start of the document.',
         'info': '{err}',
-        'help': 'The XML prolog specifies how a computer must read the rest of the XML file. It looks something like `<?xml version="1.0" encoding="UTF-8"?>`. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nFor more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
+        'help': 'The XML prolog specifies how a computer must read the rest of the XML file. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nIt looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`.\nFor more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
     }
 }
 
@@ -297,7 +297,7 @@ def _check_is_xml(maybe_xml):
     try:
         _ = etree.fromstring(maybe_xml.strip())
     except etree.XMLSyntaxError as parse_errors:
-        # import pdb;pdb.set_trace()
+        import pdb;pdb.set_trace()
         for err in parse_errors.error_log:
             error = _parse_xml_syntax_error(err)
             error_log.add(error)

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -295,10 +295,11 @@ def _check_is_xml(maybe_xml):
         maybe_xml = maybe_xml.xml_str
 
     try:
-        _ = etree.fromstring(maybe_xml.strip())
-    except etree.XMLSyntaxError as parse_errors:
+        parser = etree.XMLParser()
+        _ = etree.fromstring(maybe_xml.strip(), parser)
+    except etree.XMLSyntaxError:
         # import pdb;pdb.set_trace()
-        for err in parse_errors.error_log:
+        for err in parser.error_log:
             error = _parse_xml_syntax_error(err)
             error_log.add(error)
     except (AttributeError, TypeError, ValueError):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -457,10 +457,7 @@ def is_xml(maybe_xml):
     """
     error_log = _check_is_xml(maybe_xml)
 
-    if isinstance(error_log, ValidationErrorLog):
-        return not error_log.contains_errors()
-    else:
-        return error_log
+    return not error_log.contains_errors()
 
 
 def validate_is_xml(dataset):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -190,11 +190,17 @@ _ERROR_CODES = {
         'info': '{err}',
         'help': 'There are many different ways in which a file may not be valid XML. The most common of these have had specific error messages created. This is not currently one of them.\nShould it be identified that this error occurs frequently, a specific error message will be created.\nFor an introduction to XML see https://www.w3schools.com/Xml/'
     },
+    'err-not-xml-content-at-end': {
+        'category': 'xml',
+        'description': 'An XML file must contain no information after the XML has finished.',
+        'info': '{err}',
+        'help': 'An XML document contains a number of elements that are started and ended using tags. The XML is deemed finished once the number of start tags and the number of end tags is the same.\nThe contents of the data after this point does not matter - it may be valid XML on its own, or may have no meaning.\nShould it be required that additional information be in the document, XML comments may be used. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
+    },
     'err-not-xml-empty-document': {
         'category': 'xml',
-        'description': 'No XML start tag was found within the document. The XML start tag is `<`.',
+        'description': 'An XML file must start with the XML start tag. The XML start tag is `<`.',
         'info': '{err}',
-        'help': 'For an introduction to XML see https://www.w3schools.com/Xml/'
+        'help': 'An XML document must contain only valid XML.\nShould it be required that additional information be in the document, XML comments may be used. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
     }
 }
 
@@ -285,6 +291,7 @@ def _check_is_xml(maybe_xml):
     try:
         _ = etree.fromstring(maybe_xml.strip())
     except etree.XMLSyntaxError as parse_errors:
+        # import pdb;pdb.set_trace()
         for err in parse_errors.error_log:
             error = _parse_xml_syntax_error(err)
             error_log.add(error)
@@ -328,7 +335,8 @@ def _parse_xml_syntax_error(err):
 
     # undertake the mapping between error name formats
     lxml_to_iati_error_mapping = {
-        'ERR_DOCUMENT_EMPTY': 'err-not-xml-empty-document'
+        'ERR_DOCUMENT_EMPTY': 'err-not-xml-empty-document',
+        'ERR_DOCUMENT_END': 'err-not-xml-content-at-end'
     }
 
     try:

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -200,7 +200,13 @@ _ERROR_CODES = {
         'category': 'xml',
         'description': 'An XML file must start with the XML start tag. The XML start tag is `<`.',
         'info': '{err}',
-        'help': 'An XML document must contain only valid XML.\nShould it be required that additional information be in the document, XML comments may be used. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
+        'help': 'An XML document must contain only valid XML.\nShould it be required that additional information be in the document, XML comments may be used. Comments may not, however, be right at the very start of the document. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
+    },
+    'err-not-xml-xml-prolog-only-at-doc-start': {
+        'category': 'xml',
+        'description': 'The XML prolog must occur at the start of the document.',
+        'info': '{err}',
+        'help': 'The XML prolog specifies how a computer must read the rest of the XML file. It looks something like `<?xml version="1.0" encoding="UTF-8"?>`. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nFor more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
     }
 }
 
@@ -336,7 +342,8 @@ def _parse_xml_syntax_error(err):
     # undertake the mapping between error name formats
     lxml_to_iati_error_mapping = {
         'ERR_DOCUMENT_EMPTY': 'err-not-xml-empty-document',
-        'ERR_DOCUMENT_END': 'err-not-xml-content-at-end'
+        'ERR_DOCUMENT_END': 'err-not-xml-content-at-end',
+        'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-prolog-only-at-doc-start'
     }
 
     try:

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -338,6 +338,8 @@ def is_xml(maybe_xml):
     try:
         _ = etree.fromstring(maybe_xml.strip())
         return True
-    except (etree.XMLSyntaxError, AttributeError, TypeError, ValueError):
+    except etree.XMLSyntaxError as err:
+        return False
+    except (AttributeError, TypeError, ValueError):
         return False
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -27,6 +27,8 @@ class ValidationError(object):
             raise ValueError('{err_name} is not a known type of ValidationError.'.format(**locals()))
 
         # set general attributes for this type of error
+        self.name = err_name
+
         for key, val in err_detail.items():
             setattr(self, key, val)
 
@@ -97,6 +99,21 @@ class ValidationErrorLog(object):
             raise TypeError('Only ValidationErrors may be added to a ValidationErrorLog.')
 
         self._values.append(value)
+
+    def contains_error_called(self, err_name):
+        """Check the log for an error or warning with the specified name.
+
+        Args:
+            err_name (str): The name of the error to look for.
+
+        Returns:
+            bool: Whether there is an error or warning with the specified name within the log.
+
+        """
+        errors_with_name = [err for err in self._values if err.name == err_name]
+
+        return len(errors_with_name) > 0
+
 
     def extend(self, values):
         """Extend the ErrorLog with ValidationErrors from an iterable.

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -335,6 +335,9 @@ def _parse_xml_syntax_error(err):
     Returns:
         ValidationError: An IATI ValidationError that contains the information from the log entry.
 
+    Todo:
+        Create a small program to determine the common types of errors so that they can be handled as special cases with detailed help info.
+
     """
     # configure local variables for the creation of the error
     line_number = err.line


### PR DESCRIPTION
When `is_xml()` indicates that a value is not XML, errors are produced.

This PR adds such errors to a `ValidationErrorLog`.