### PR TITLE
Switch Dataset creation to use iati.validator

### DIFF
--- a/iati/core/data.py
+++ b/iati/core/data.py
@@ -64,7 +64,7 @@ class Dataset(object):
         """Return a string representation of the XML being represented.
 
         Raises:
-            ValueError: If a value that is being assigned is not a valid XML string.
+            iati.core.exceptions.ValidationError: If a value that is being assigned is not a valid XML string.
             TypeError: If a value that is being assigned is not a string at all.
 
         Todo:
@@ -91,16 +91,16 @@ class Dataset(object):
                 else:
                     value_stripped_bytes = value_stripped
 
-                if iati.validator.is_xml(value_stripped_bytes):
+                validation_error_log = iati.validator.validate_is_xml(value_stripped_bytes)
+
+                if not validation_error_log.contains_errors():
                     self.xml_tree = etree.fromstring(value_stripped_bytes)
                     self._xml_str = value_stripped
                 else:
-                    err_log = iati.validator.validate_is_xml(value_stripped_bytes)
-                    if err_log.contains_error_of_type(TypeError):
+                    if validation_error_log.contains_error_of_type(TypeError):
                         raise TypeError
-                    msg = "The string provided to create a Dataset from is not valid XML."
-                    iati.core.utilities.log_error(msg)
-                    raise ValueError(msg)
+                    else:
+                        raise iati.core.exceptions.ValidationError(validation_error_log)
             except (AttributeError, TypeError):
                 msg = "Datasets can only be ElementTrees or strings containing valid XML, using the xml_tree and xml_str attributes respectively. Actual type: {0}".format(type(value))
                 iati.core.utilities.log_error(msg)

--- a/iati/core/data.py
+++ b/iati/core/data.py
@@ -96,7 +96,7 @@ class Dataset(object):
                     self._xml_str = value_stripped
                 else:
                     err_log = iati.validator.validate_is_xml(value_stripped_bytes)
-                    if err_log.contains_error_called('err-not-xml-not-string'):
+                    if err_log.contains_error_of_type(TypeError):
                         raise TypeError
                     msg = "The string provided to create a Dataset from is not valid XML."
                     iati.core.utilities.log_error(msg)

--- a/iati/core/exceptions.py
+++ b/iati/core/exceptions.py
@@ -28,4 +28,8 @@ class ValidationError(ValueError):
         This is too general to identify many specific problems.
     """
 
-    pass
+    def __init__(self, error_log):
+        """Initialise a ValidationError."""
+        self.error_log = error_log
+
+        super(ValidationError, self).__init__()

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -49,10 +49,8 @@ class TestDatasets(object):
 
     def test_dataset_invalid_xml_string(self):
         """Test Dataset creation with a string that is not valid XML."""
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
-
-        assert 'The string provided to create a Dataset from is not valid XML.' == str(excinfo.value)
 
     @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_dataset_number_not_xml(self, not_xml):
@@ -95,10 +93,8 @@ class TestDatasets(object):
         """Test assignment to the xml_str property with an invalid XML string."""
         data = dataset_initialised
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             data.xml_str = iati.core.tests.utilities.XML_STR_INVALID
-
-        assert 'The string provided to create a Dataset from is not valid XML.' == str(excinfo.value)
 
     def test_dataset_xml_str_assignment_tree(self, dataset_initialised):
         """Test assignment to the xml_str property with an ElementTree."""
@@ -219,10 +215,8 @@ class TestDatasets(object):
         </iati-activities>""".format(encoding_declared)
         xml_encoded = xml.encode(encoding_used)  # Encode the whole string in line with the specified encoding
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             dataset = iati.core.data.Dataset(xml_encoded)
-
-        assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
 
 class TestDatasetSourceFinding(object):

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -194,12 +194,13 @@ class TestDatasets(object):
         ("UTF-16", "UTF-8"),
         ("UTF-16", "ISO-8859-1"),
         ("UTF-16", "BIG5"),
-        ("UTF-16", "EUC-JP"),
-        ("ASCII", "UTF-16"),
-        ("ISO-8859-1", "UTF-16"),
-        ("ISO-8859-2", "UTF-16"),
-        ("BIG5", "UTF-16"),
-        ("EUC-JP", "UTF-16")])
+        ("UTF-16", "EUC-JP")
+        # ("ASCII", "UTF-16"),
+        # ("ISO-8859-1", "UTF-16")
+        # ("ISO-8859-2", "UTF-16"),
+        # ("BIG5", "UTF-16"),
+        # ("EUC-JP", "UTF-16")
+    ])
     def test_instantiation_dataset_from_string_with_encoding_mismatch(self, encoding_declared, encoding_used):
         """Test that an error is raised when attempting to create a dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
 
@@ -216,7 +217,30 @@ class TestDatasets(object):
         xml_encoded = xml.encode(encoding_used)  # Encode the whole string in line with the specified encoding
 
         with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
-            dataset = iati.core.data.Dataset(xml_encoded)
+            _ = iati.core.data.Dataset(xml_encoded)
+
+        assert excinfo.value.error_log.contains_error_called('err-encoding-invalid')
+
+    @pytest.mark.parametrize("encoding", ["CP424"])
+    def test_instantiation_dataset_from_string_with_unsupported_encoding(self, encoding):
+        """Test that an error is raised when attempting to create a dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
+
+        Todo:
+            Amend error message, when the todo in iati.core.data.Dataset.xml_str() has been resolved.
+
+        """
+        xml = """<?xml version="1.0" encoding="{}"?>
+        <iati-activities version="xx">
+          <iati-activity>
+             <iati-identifier></iati-identifier>
+         </iati-activity>
+        </iati-activities>""".format(encoding)
+        xml_encoded = xml.encode(encoding)  # Encode the whole string in line with the specified encoding
+
+        with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
+            _ = iati.core.data.Dataset(xml_encoded)
+
+        assert excinfo.value.error_log.contains_error_called('err-encoding-unsupported')
 
 
 class TestDatasetSourceFinding(object):

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -225,6 +225,11 @@ class TestDatasetWithEncoding(object):
         Note:
             There are a number of other errors that may be raised with alternative encoding mismatches. These are not supported since it does not appear likely enough that they will occur and be a large issue in practice.
 
+            This is due to a pair of issues with libxml2 (the underlying library behind lxml):
+
+            1. It only supports a limited number of encodings out-of-the-box.
+            2. Different encoding pairs (whether supported or unsupported by libxml2; byte-equivalent-subsets or distinct encodings; and more), will return different error codes in what one would expect to act as equivalent situations.
+
         """
         xml = xml_needing_encoding.format(encoding_declared)
         xml_encoded = xml.encode(encoding_used)  # Encode the whole string in line with the specified encoding

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -52,6 +52,8 @@ class TestDatasets(object):
         with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
 
+        assert excinfo.value.error_log.contains_error_called('err-not-xml-empty-document')
+
     @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
     def test_dataset_number_not_xml(self, not_xml):
         """Test Dataset creation when it's passed a number rather than a string or etree."""
@@ -95,6 +97,8 @@ class TestDatasets(object):
 
         with pytest.raises(iati.core.exceptions.ValidationError) as excinfo:
             data.xml_str = iati.core.tests.utilities.XML_STR_INVALID
+
+        excinfo.value.error_log.contains_error_called('err-not-xml-empty-document')
 
     def test_dataset_xml_str_assignment_tree(self, dataset_initialised):
         """Test assignment to the xml_str property with an ElementTree."""

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -193,19 +193,18 @@ class TestDatasets(object):
     @pytest.mark.parametrize("encoding_declared, encoding_used", [
         ("UTF-16", "UTF-8"),
         ("UTF-16", "ISO-8859-1"),
+        ("UTF-16", "ASCII"),
         ("UTF-16", "BIG5"),
         ("UTF-16", "EUC-JP")
-        # ("ASCII", "UTF-16"),
-        # ("ISO-8859-1", "UTF-16")
-        # ("ISO-8859-2", "UTF-16"),
-        # ("BIG5", "UTF-16"),
-        # ("EUC-JP", "UTF-16")
     ])
     def test_instantiation_dataset_from_string_with_encoding_mismatch(self, encoding_declared, encoding_used):
         """Test that an error is raised when attempting to create a dataset where a string is encoded significantly differently from what is defined within the XML encoding declaration.
 
         Todo:
             Amend error message, when the todo in iati.core.data.Dataset.xml_str() has been resolved.
+
+        Note:
+            There are a number of other errors that may be raised with alternative encoding mismatches. These are not supported since it does not appear likely enough that they will occur and be a large issue in practice.
 
         """
         xml = """<?xml version="1.0" encoding="{}"?>

--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -267,8 +267,8 @@ class TestValidateIsXML(object):
         return request.param
 
     @pytest.fixture
-    def xml_str_no_prolog(self, xml_str):
-        """A valid XML string with the prolog removed."""
+    def xml_str_no_text_decl(self, xml_str):
+        """A valid XML string with the text declaration removed."""
         return '\n'.join(xml_str.strip().split('\n')[1:])
 
     @pytest.fixture(params=iati.core.tests.utilities.find_parameter_by_type(['str'], False) + [iati.core.tests.utilities.XML_STR_INVALID])
@@ -317,15 +317,15 @@ class TestValidateIsXML(object):
 
         assert len(result) == 0
 
-    def test_xml_check_valid_xml_str_comments_before_no_prolog_detailed_output(self, xml_str_no_prolog, str_not_xml):
+    def test_xml_check_valid_xml_str_comments_before_no_text_decl_detailed_output(self, xml_str_no_text_decl, str_not_xml):
         """Perform check to see whether a string is valid XML.
 
         The string is valid XML.
-        There is a comment added before the XML. There is no XML prolog.
+        There is a comment added before the XML. There is no XML text declaration.
         Obtain detailed error output.
         """
         comment = '<!-- ' + str_not_xml + ' -->'
-        xml_prefixed_with_comment = comment + xml_str_no_prolog
+        xml_prefixed_with_comment = comment + xml_str_no_text_decl
 
         result = iati.validator.validate_is_xml(xml_prefixed_with_comment)
 
@@ -380,7 +380,7 @@ class TestValidateIsXML(object):
     def test_xml_check_not_xml_str_comments_before_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        There is a comment added before the XML. The XML contains a prolog.
+        There is a comment added before the XML. The XML contains a text declaration.
         Obtain detailed error output.
         """
         comment = '<!-- ' + str_not_xml + ' -->'
@@ -389,7 +389,7 @@ class TestValidateIsXML(object):
         result = iati.validator.validate_is_xml(not_xml)
 
         assert result.contains_errors()
-        assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
+        assert result.contains_error_called('err-not-xml-xml-text-decl-only-at-doc-start')
 
     def test_xml_check_not_xml_str_text_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
@@ -407,7 +407,7 @@ class TestValidateIsXML(object):
     def test_xml_check_not_xml_str_xml_after_xml_detailed_output(self, xml_str, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        The string is two concatenated XML strings. Each contains a prolog.
+        The string is two concatenated XML strings. Each contains a text declaration.
         Obtain detailed error output.
         """
         not_xml = xml_str + xml_str
@@ -417,15 +417,15 @@ class TestValidateIsXML(object):
         assert len(result) == 2
         assert result.contains_errors()
         assert result.contains_error_called('err-not-xml-content-at-end')
-        assert result.contains_error_called('err-not-xml-xml-prolog-only-at-doc-start')
+        assert result.contains_error_called('err-not-xml-xml-text-decl-only-at-doc-start')
 
-    def test_xml_check_not_xml_str_xml_after_xml_no_prolog_detailed_output(self, xml_str_no_prolog, str_not_xml):
+    def test_xml_check_not_xml_str_xml_after_xml_no_text_decl_detailed_output(self, xml_str_no_text_decl, str_not_xml):
         """Perform check to locate the XML Syntax Errors in a string.
 
-        The string is two concatenated XML strings. Each contains a prolog.
+        The string is two concatenated XML strings. Each contains a text declaration.
         Obtain detailed error output.
         """
-        not_xml = xml_str_no_prolog + xml_str_no_prolog
+        not_xml = xml_str_no_text_decl + xml_str_no_text_decl
 
         result = iati.validator.validate_is_xml(not_xml)
 

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -228,6 +228,20 @@ _ERROR_CODES = {
         'description': 'The XML prolog must occur at the start of the document.',
         'info': '{err}',
         'help': 'The XML prolog specifies how a computer must read the rest of the XML file. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nIt looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`.\nFor more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
+    },
+    'err-encoding-invalid': {
+        'base_exception': ValueError,
+        'category': 'file',
+        'description': 'The encoding specified within the XML prolog is different from the actual encoding of the XML file.',
+        'info': '{err}',
+        'help': 'The encoding of a file specifies how a computer should interpret the 1s and 0s that it is made up of. For more information about encoding, see https://www.w3.org/International/questions/qa-what-is-encoding\nThe XML prolog looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`. For more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
+    },
+    'err-encoding-unsupported': {
+        'base_exception': ValueError,
+        'category': 'file',
+        'description': 'The encoding of the XML file is not supported by a tool used by IATI.',
+        'info': '{err}',
+        'help': 'The encoding of a file specifies how a computer should interpret the 1s and 0s that it is made up of. For more information about encoding, see https://www.w3.org/International/questions/qa-what-is-encoding'
     }
 }
 
@@ -368,8 +382,12 @@ def _parse_xml_syntax_error(err):
     lxml_to_iati_error_mapping = {
         'ERR_DOCUMENT_EMPTY': 'err-not-xml-empty-document',
         'ERR_DOCUMENT_END': 'err-not-xml-content-at-end',
+        'ERR_INVALID_ENCODING': 'err-encoding-invalid',
+        'ERR_UNSUPPORTED_ENCODING': 'err-encoding-unsupported',
         'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-prolog-only-at-doc-start'
     }
+
+    # import pdb;pdb.set_trace()
 
     try:
         err_name = lxml_to_iati_error_mapping[err.type_name]

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -331,7 +331,7 @@ def _check_is_xml(maybe_xml):
 
     try:
         parser = etree.XMLParser()
-        _ = etree.fromstring(maybe_xml.strip(), parser)
+        hi = etree.fromstring(maybe_xml.strip(), parser)
     except etree.XMLSyntaxError:
         # import pdb;pdb.set_trace()
         for err in parser.error_log:
@@ -386,8 +386,6 @@ def _parse_xml_syntax_error(err):
         'ERR_UNSUPPORTED_ENCODING': 'err-encoding-unsupported',
         'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-prolog-only-at-doc-start'
     }
-
-    # import pdb;pdb.set_trace()
 
     try:
         err_name = lxml_to_iati_error_mapping[err.type_name]

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -222,19 +222,19 @@ _ERROR_CODES = {
         'info': '{err}',
         'help': 'An XML document must contain only valid XML.\nShould it be required that additional information be in the document, XML comments may be used. Comments may not, however, be right at the very start of the document. For information about comments in XML, see https://www.w3schools.com/xml/xml_syntax.asp'
     },
-    'err-not-xml-xml-prolog-only-at-doc-start': {
+    'err-not-xml-xml-text-decl-only-at-doc-start': {
         'base_exception': ValueError,
         'category': 'xml',
-        'description': 'The XML prolog must occur at the start of the document.',
+        'description': 'The XML text declaration must occur at the start of the document.',
         'info': '{err}',
-        'help': 'The XML prolog specifies how a computer must read the rest of the XML file. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nIt looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`.\nFor more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
+        'help': 'The XML text declaration specifies how a computer must read the rest of the XML file. Since it tells the computer how to read the XML file, it must occur at the start of an XML document without any content before it.\nIt looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`.\nFor more information about the XML text declaration, see https://www.w3schools.com/xml/xml_syntax.asp and https://www.w3.org/TR/2000/REC-xml-20001006#sec-TextDecl'
     },
     'err-encoding-invalid': {
         'base_exception': ValueError,
         'category': 'file',
-        'description': 'The encoding specified within the XML prolog is different from the actual encoding of the XML file.',
+        'description': 'The encoding specified within the XML text declaration is different from the actual encoding of the XML file.',
         'info': '{err}',
-        'help': 'The encoding of a file specifies how a computer should interpret the 1s and 0s that it is made up of. For more information about encoding, see https://www.w3.org/International/questions/qa-what-is-encoding\nThe XML prolog looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`. For more information about the XML prolog, see https://www.w3schools.com/xml/xml_syntax.asp'
+        'help': 'The encoding of a file specifies how a computer should interpret the 1s and 0s that it is made up of. For more information about encoding, see https://www.w3.org/International/questions/qa-what-is-encoding\nThe XML text declaration looks similar to: `<?xml version="1.0" encoding="UTF-8"?>`. For more information about the XML text declaration, see https://www.w3schools.com/xml/xml_syntax.asp and https://www.w3.org/TR/2000/REC-xml-20001006#sec-TextDecl'
     },
     'err-encoding-unsupported': {
         'base_exception': ValueError,
@@ -384,7 +384,7 @@ def _parse_xml_syntax_error(err):
         'ERR_DOCUMENT_END': 'err-not-xml-content-at-end',
         'ERR_INVALID_ENCODING': 'err-encoding-invalid',
         'ERR_UNSUPPORTED_ENCODING': 'err-encoding-unsupported',
-        'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-prolog-only-at-doc-start'
+        'ERR_RESERVED_XML_NAME': 'err-not-xml-xml-text-decl-only-at-doc-start'
     }
 
     try:

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -331,7 +331,7 @@ def _check_is_xml(maybe_xml):
 
     try:
         parser = etree.XMLParser()
-        hi = etree.fromstring(maybe_xml.strip(), parser)
+        _ = etree.fromstring(maybe_xml.strip(), parser)
     except etree.XMLSyntaxError:
         # import pdb;pdb.set_trace()
         for err in parser.error_log:


### PR DESCRIPTION
By using validator to determine whether something is XML, the code is more DRY. It also allows more detailed errors to be provided.

This change makes `iati.validator` a dependency of `iati.core`.