### PR TITLE
Filter file names before access - fixes #18

### DIFF
--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -85,10 +85,10 @@ def get_all_codelist_paths(version=None):
 
     """
     files = pkg_resources.resource_listdir(PACKAGE, get_path_for_version(PATH_CODELISTS, version))
-    paths = [get_codelist_path(file, version) for file in files]
-    paths_codelists_only = [path for path in paths if path[-4:] == FILE_CODELIST_EXTENSION]
+    files_codelists_only = [file_name for file_name in files if file_name[-4:] == FILE_CODELIST_EXTENSION]
+    paths = [get_codelist_path(file_name, version) for file_name in files_codelists_only]
 
-    return paths_codelists_only
+    return paths
 
 
 def get_all_schema_paths(version=None):


### PR DESCRIPTION
The check for whether a file had the Codelist extension was being performed after trying to load the file. This was causing non-Codelist files to be looked for.

The check is now being performed before attempting to load the files so that it's less likely that a file will not be found. Note that there may still be errors raised should a file be deleted in the time between the check and the loading.

Fixes #18 