### PR TITLE
Rename test function generate_test_types() - fixes #63

### DIFF
--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -54,7 +54,7 @@ class TestDatasets(object):
 
         assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
-    @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_dataset_number_not_xml(self, not_xml):
         """Test Dataset creation when it's passed a number rather than a string or etree."""
         with pytest.raises(TypeError) as excinfo:
@@ -109,7 +109,7 @@ class TestDatasets(object):
 
         assert str(excinfo.value) == 'If setting a dataset with an ElementTree, use the xml_tree property, not the xml_str property.'
 
-    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_dataset_xml_str_assignment_invalid_value(self, dataset_initialised, invalid_value):
         """Test assignment to the xml_str property with a value that is very much not valid."""
         data = dataset_initialised
@@ -148,7 +148,7 @@ class TestDatasets(object):
 
         assert 'If setting a dataset with the xml_property, an ElementTree should be provided, not a' in str(excinfo.value)
 
-    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_dataset_xml_tree_assignment_invalid_value(self, dataset_initialised, invalid_value):
         """Test assignment to the xml_tree property with a value that is very much not valid."""
         data = dataset_initialised
@@ -283,7 +283,7 @@ class TestDatasetSourceFinding(object):
         with pytest.raises(ValueError):
             data.source_at_line(num_lines_xml)
 
-    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.find_parameter_by_type(['int'], False))
+    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.generate_test_types(['int'], True))
     def test_dataset_xml_str_source_at_line_invalid_line_type(self, invalid_value, data):
         """Test obtaining source of a particular line. Line numbers are not valid."""
         with pytest.raises(TypeError):
@@ -390,7 +390,7 @@ class TestDatasetSourceFinding(object):
             with pytest.raises(ValueError):
                 data.source_around_line(line_num, -1)
 
-    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.find_parameter_by_type(['int'], False))
+    @pytest.mark.parametrize("invalid_value", iati.core.tests.utilities.generate_test_types(['int'], True))
     def test_dataset_xml_str_source_around_line_invalid_context_lines(self, invalid_value, data, num_lines_xml):
         """Test obtaining source of a particular line.
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -25,7 +25,7 @@ class TestDefault(object):
         for code in codelist.codes:
             assert isinstance(code, iati.core.Code)
 
-    @pytest.mark.parametrize("name", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("name", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_default_codelist_invalid(self, name):
         """Check that trying to find a default Codelist with an invalid name raises an error."""
         with pytest.raises(ValueError) as excinfo:
@@ -89,7 +89,7 @@ class TestDefault(object):
         for schema in schemas[version].values():
             assert isinstance(schema, (iati.core.ActivitySchema, iati.core.OrganisationSchema))
 
-    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.find_parameter_by_type([], False))
+    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.generate_test_types([], True))
     def test_default_schema(self, invalid_name):
         """Check that an Error is raised when attempting to load a Schema name that does not exist."""
         with pytest.raises((ValueError, TypeError)):

--- a/iati/core/tests/test_utilities.py
+++ b/iati/core/tests/test_utilities.py
@@ -73,7 +73,7 @@ class TestUtilities(object):
 
         assert 'There is already a namespace called' in str(excinfo.value)
 
-    @pytest.mark.parametrize("not_a_tree", iati.core.tests.utilities.find_parameter_by_type([], False))
+    @pytest.mark.parametrize("not_a_tree", iati.core.tests.utilities.generate_test_types([], True))
     def test_add_namespace_no_schema(self, not_a_tree):
         """Check that attempting to add a namespace to something that isn't a Schema raises an error."""
         ns_name = 'xsd'
@@ -84,7 +84,7 @@ class TestUtilities(object):
 
         assert 'The `tree` parameter must be of type `etree._ElementTree` - it was of type' in str(excinfo.value)
 
-    @pytest.mark.parametrize("ns_name", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("ns_name", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_add_namespace_nsname_non_str(self, ns_name):
         """Check that attempting to add a namespace with a name that is not a string acts correctly.
 
@@ -110,7 +110,7 @@ class TestUtilities(object):
 
         assert 'The `new_ns_name` parameter must be a non-empty string.' in str(excinfo.value)
 
-    @pytest.mark.parametrize("ns_uri", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("ns_uri", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_add_namespace_nsuri_non_str(self, ns_uri):
         """Check that attempting to add a namespace uri that is not a string acts correctly.
 
@@ -168,7 +168,7 @@ class TestUtilities(object):
 
         assert excinfo.typename == 'XMLSyntaxError'
 
-    @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.find_parameter_by_type(['str'], False))
+    @pytest.mark.parametrize("not_xml", iati.core.tests.utilities.generate_test_types(['str'], True))
     def test_convert_xml_to_tree_not_str(self, not_xml):
         """Check that an invalid string raises an error when an attempt is made to convert it to an etree."""
         with pytest.raises(ValueError) as excinfo:

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -95,19 +95,19 @@ TYPE_TEST_DATA = {
 """Generic test data of various Python builtin types."""
 
 
-def find_parameter_by_type(types, type_as_specified=True):
+def generate_test_types(types, invert_types=False):
     """Find a number of values of the specified type to pass to a test function.
 
     Args:
         types (list of str): The types of parameter that should be looked for.
-        type_as_specified (bool): Whether to look for values as specified or everything else. Default True.
+        invert_types (bool): Whether to invert the list of types being looked for, instead returning everything else. Default False.
 
     Returns:
         list: A list of values to pass to the test function.
 
     """
     valid_keys_as_specified = [key for key in types if key in TYPE_TEST_DATA]
-    if not type_as_specified:
+    if invert_types:
         valid_keys = [key for key in TYPE_TEST_DATA.keys() if key not in valid_keys_as_specified]
     else:
         valid_keys = valid_keys_as_specified


### PR DESCRIPTION
The new name is clearer in what it does. A parameter has also been inverted to make slightly more sense.

Based on #63

Three find+replace regex pairs for conversion:

* `iati\.core\.tests\.utilities\.find_parameter_by_type\((\[(.*,?\s?)?\]),\s?False\)` -> `iati\.core\.tests\.utilities\.generate_test_types\($1, True\)`
* `iati\.core\.tests\.utilities\.find_parameter_by_type\((\[(.*,?\s?)?\]),\s?True\)` -> `iati\.core\.tests\.utilities\.generate_test_types\($1, False\)`
* `iati\.core\.tests\.utilities\.find_parameter_by_type\((\[(.*,?\s?)?\])\)` -> `iati\.core\.tests\.utilities\.generate_test_types\($1\)`