### PR TITLE
Make tests/utilities.py easier to read

### DIFF
--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -19,7 +19,7 @@ class TestDatasets(object):
     @pytest.fixture
     def dataset_initialised(self):
         """Return an initialised dataset to work from in other tests."""
-        return iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
+        return iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati'))
 
     def test_dataset_no_params(self):
         """Test Dataset creation with no parameters."""
@@ -30,17 +30,17 @@ class TestDatasets(object):
 
     def test_dataset_valid_xml_string(self):
         """Test Dataset creation with a valid XML string that is not IATI data."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati'))
 
-        assert data.xml_str == iati.core.tests.utilities.XML_STR_VALID_NOT_IATI.strip()
+        assert data.xml_str == iati.core.tests.utilities.load_as_string('valid_not_iati').strip()
         assert etree.tostring(data.xml_tree) == etree.tostring(iati.core.tests.utilities.XML_TREE_VALID)
 
     def test_dataset_xml_string_leading_whitespace(self):
         """Test Dataset creation with a valid XML string that is not IATI data."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE)
-        tree = etree.fromstring(iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE.strip())
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('leading_whitespace_xml'))
+        tree = etree.fromstring(iati.core.tests.utilities.load_as_string('leading_whitespace_xml').strip())
 
-        assert data.xml_str == iati.core.tests.utilities.XML_STR_LEADING_WHITESPACE.strip()
+        assert data.xml_str == iati.core.tests.utilities.load_as_string('leading_whitespace_xml').strip()
         assert etree.tostring(data.xml_tree) == etree.tostring(tree)
 
     def test_dataset_valid_iati_string(self):
@@ -50,7 +50,7 @@ class TestDatasets(object):
     def test_dataset_invalid_xml_string(self):
         """Test Dataset creation with a string that is not valid XML."""
         with pytest.raises(ValueError) as excinfo:
-            iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID)
+            iati.core.Dataset(iati.core.tests.utilities.load_as_string('invalid'))
 
         assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
@@ -87,16 +87,16 @@ class TestDatasets(object):
 
         """
         data = dataset_initialised
-        data.xml_str = iati.core.tests.utilities.XML_STR_VALID_NOT_IATI
+        data.xml_str = iati.core.tests.utilities.load_as_string('valid_not_iati')
 
-        assert data.xml_str == iati.core.tests.utilities.XML_STR_VALID_NOT_IATI.strip()
+        assert data.xml_str == iati.core.tests.utilities.load_as_string('valid_not_iati').strip()
 
     def test_dataset_xml_str_assignment_invalid_str(self, dataset_initialised):
         """Test assignment to the xml_str property with an invalid XML string."""
         data = dataset_initialised
 
         with pytest.raises(ValueError) as excinfo:
-            data.xml_str = iati.core.tests.utilities.XML_STR_INVALID
+            data.xml_str = iati.core.tests.utilities.load_as_string('invalid')
 
         assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
@@ -144,7 +144,7 @@ class TestDatasets(object):
         """Test assignment to the xml_tree property with an XML string."""
         data = dataset_initialised
         with pytest.raises(TypeError) as excinfo:
-            data.xml_tree = iati.core.tests.utilities.XML_STR_VALID_NOT_IATI
+            data.xml_tree = iati.core.tests.utilities.load_as_string('valid_not_iati')
 
         assert 'If setting a dataset with the xml_property, an ElementTree should be provided, not a' in str(excinfo.value)
 
@@ -230,8 +230,8 @@ class TestDatasetSourceFinding(object):
 
 
     @pytest.fixture(params=[
-        iati.core.tests.utilities.XML_STR_VALID_NOT_IATI,
-        iati.core.tests.utilities.XML_STR_VALID_IATI
+        iati.core.tests.utilities.load_as_string('valid_not_iati'),
+        iati.core.tests.utilities.load_as_string('valid_iati')
     ])
     def data(self, request):
         """A Dataset to test."""
@@ -265,7 +265,7 @@ class TestDatasetSourceFinding(object):
 
         Ensure that the line numbers from which source is being returned are the same ones provided by the `sourceline` attribute from tree elements.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI.strip())
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati').strip())
         split_xml_str = [''] + data.xml_str.split('\n')
         line_num = line_el_pair['line']
         el_from_tree = data.xml_tree.xpath(line_el_pair['el'])[0]

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -45,8 +45,6 @@ XML_STR_VALID_IATI_INVALID_CODE = load_as_string('valid_iati_invalid_code')
 """A string containing valid IATI XML, but an invalid Code valid."""
 XML_STR_INVALID = load_as_string('invalid')
 """A string that is not valid XML."""
-XML_STR_LEADING_WHITESPACE = load_as_string('leading_whitespace_xml')
-"""A string containing valid XML apart form leading whitepace before an `<?xml` declaration."""
 
 XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT = load_as_string('invalid_iati_missing_required_element')
 """A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -6,7 +6,7 @@ Example:
     To load a file into a string::
 
         name_of_file = 'a-file-name-without-the-extension'
-        CONSTANT_NAME = _load_as_string(name_of_file)
+        CONSTANT_NAME = load_as_string(name_of_file)
 
 Note:
     The current method of managing test data is known to be sub-optimal. Suggestions for better methods that satisfy requirements are appreciated!
@@ -20,7 +20,7 @@ from lxml import etree
 import iati.core.resources
 
 
-def _load_as_string(file_path):
+def load_as_string(file_path):
     """Load a specified test data file as a string.
 
     Args:
@@ -37,42 +37,42 @@ SCHEMA_ACTIVITY_NAME_VALID = 'iati-activities-schema'
 SCHEMA_ORGANISATION_NAME_VALID = 'iati-organisations-schema'
 """A string containing a valid IATI Organisaion Schema name."""
 
-XML_STR_VALID_NOT_IATI = _load_as_string('valid_not_iati')
+XML_STR_VALID_NOT_IATI = load_as_string('valid_not_iati')
 """A string containing valid XML that is not valid against the IATI schema."""
-XML_STR_VALID_IATI = _load_as_string('valid_iati')
+XML_STR_VALID_IATI = load_as_string('valid_iati')
 """A string containing valid IATI XML."""
-XML_STR_VALID_IATI_INVALID_CODE = _load_as_string('valid_iati_invalid_code')
+XML_STR_VALID_IATI_INVALID_CODE = load_as_string('valid_iati_invalid_code')
 """A string containing valid IATI XML, but an invalid Code valid."""
-XML_STR_INVALID = _load_as_string('invalid')
+XML_STR_INVALID = load_as_string('invalid')
 """A string that is not valid XML."""
-XML_STR_LEADING_WHITESPACE = _load_as_string('leading_whitespace_xml')
+XML_STR_LEADING_WHITESPACE = load_as_string('leading_whitespace_xml')
 """A string containing valid XML apart form leading whitepace before an `<?xml` declaration."""
 
-XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT = _load_as_string('invalid_iati_missing_required_element')
+XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT = load_as_string('invalid_iati_missing_required_element')
 """A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
-XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON = _load_as_string('invalid_iati_missing_required_element_from_common')
+XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON = load_as_string('invalid_iati_missing_required_element_from_common')
 """A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
 
-XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON = _load_as_string('valid_iati_valid_code_from_common')
+XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON = load_as_string('valid_iati_valid_code_from_common')
 """A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value on the appropriate Codelist."""
-XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON = _load_as_string('valid_iati_invalid_code_from_common')
+XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON = load_as_string('valid_iati_invalid_code_from_common')
 """A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value that is not on the appropriate Codelist."""
 
-XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = _load_as_string('valid_iati_vocab_default_explicit')
+XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = load_as_string('valid_iati_vocab_default_explicit')
 """A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = _load_as_string('valid_iati_vocab_default_implicit')
+XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = load_as_string('valid_iati_vocab_default_implicit')
 """A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = _load_as_string('valid_iati_vocab_default_implicit_invalid_code')
+XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = load_as_string('valid_iati_vocab_default_implicit_invalid_code')
 """A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code not in list."""
-XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = _load_as_string('valid_iati_vocab_non_default')
+XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = load_as_string('valid_iati_vocab_non_default')
 """A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines non-default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED = _load_as_string('valid_iati_vocab_user_defined')
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED = load_as_string('valid_iati_vocab_user_defined')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = _load_as_string('valid_iati_vocab_user_defined_with_uri_readable')
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = load_as_string('valid_iati_vocab_user_defined_with_uri_readable')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code from this list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE = _load_as_string('valid_iati_vocab_user_defined_with_uri_readable_bad_code')
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE = load_as_string('valid_iati_vocab_user_defined_with_uri_readable_bad_code')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code not in list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE = _load_as_string('valid_iati_vocab_user_defined_with_uri_unreadable')
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE = load_as_string('valid_iati_vocab_user_defined_with_uri_unreadable')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and not machine readable."""
 
 XML_TREE_VALID = etree.fromstring(XML_STR_VALID_NOT_IATI)

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -6,7 +6,7 @@ Example:
     To load a file into a string::
 
         name_of_file = 'a-file-name-without-the-extension'
-        CONSTANT_NAME = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(name_of_file))
+        CONSTANT_NAME = _load_as_string(name_of_file))
 
 Note:
     The current method of managing test data is known to be sub-optimal. Suggestions for better methods that satisfy requirements are appreciated!
@@ -19,47 +19,60 @@ import decimal
 from lxml import etree
 import iati.core.resources
 
+
+def _load_as_string(file_path):
+    """Load a specified test data file as a string.
+
+    Args:
+        file_path (str): The path of the file, relative to the root test data folder. Folders should be separated by a forward-slash (`/`).
+
+    Returns:
+        str (python3) / unicode (python2): The contents of the file at the specified location.
+    """
+    return iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(file_path))
+
+
 SCHEMA_ACTIVITY_NAME_VALID = 'iati-activities-schema'
 """A string containing a valid IATI Activity Schema name."""
 SCHEMA_ORGANISATION_NAME_VALID = 'iati-organisations-schema'
 """A string containing a valid IATI Organisaion Schema name."""
 
-XML_STR_VALID_NOT_IATI = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_not_iati'))
+XML_STR_VALID_NOT_IATI = _load_as_string('valid_not_iati')
 """A string containing valid XML that is not valid against the IATI schema."""
-XML_STR_VALID_IATI = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati'))
+XML_STR_VALID_IATI = _load_as_string('valid_iati')
 """A string containing valid IATI XML."""
-XML_STR_VALID_IATI_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_invalid_code'))
+XML_STR_VALID_IATI_INVALID_CODE = _load_as_string('valid_iati_invalid_code')
 """A string containing valid IATI XML, but an invalid Code valid."""
-XML_STR_INVALID = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('invalid'))
+XML_STR_INVALID = _load_as_string('invalid')
 """A string that is not valid XML."""
-XML_STR_LEADING_WHITESPACE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('leading_whitespace_xml'))
+XML_STR_LEADING_WHITESPACE = _load_as_string('leading_whitespace_xml')
 """A string containing valid XML apart form leading whitepace before an `<?xml` declaration."""
 
-XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('invalid_iati_missing_required_element'))
+XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT = _load_as_string('invalid_iati_missing_required_element')
 """A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
-XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('invalid_iati_missing_required_element_from_common'))
+XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON = _load_as_string('invalid_iati_missing_required_element_from_common')
 """A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
 
-XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_valid_code_from_common'))
+XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON = _load_as_string('valid_iati_valid_code_from_common')
 """A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value on the appropriate Codelist."""
-XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_invalid_code_from_common'))
+XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON = _load_as_string('valid_iati_invalid_code_from_common')
 """A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value that is not on the appropriate Codelist."""
 
-XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_explicit'))
+XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = _load_as_string('valid_iati_vocab_default_explicit')
 """A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_implicit'))
+XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = _load_as_string('valid_iati_vocab_default_implicit')
 """A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_default_implicit_invalid_code'))
+XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = _load_as_string('valid_iati_vocab_default_implicit_invalid_code')
 """A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code not in list."""
-XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_non_default'))
+XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = _load_as_string('valid_iati_vocab_non_default')
 """A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines non-default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined'))
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED = _load_as_string('valid_iati_vocab_user_defined')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined_with_uri_readable'))
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = _load_as_string('valid_iati_vocab_user_defined_with_uri_readable')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code from this list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined_with_uri_readable_bad_code'))
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE = _load_as_string('valid_iati_vocab_user_defined_with_uri_readable_bad_code')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code not in list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE = iati.core.resources.load_as_string(iati.core.resources.get_test_data_path('valid_iati_vocab_user_defined_with_uri_unreadable'))
+XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE = _load_as_string('valid_iati_vocab_user_defined_with_uri_unreadable')
 """A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and not machine readable."""
 
 XML_TREE_VALID = etree.fromstring(XML_STR_VALID_NOT_IATI)

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -37,47 +37,11 @@ SCHEMA_ACTIVITY_NAME_VALID = 'iati-activities-schema'
 SCHEMA_ORGANISATION_NAME_VALID = 'iati-organisations-schema'
 """A string containing a valid IATI Organisaion Schema name."""
 
-XML_STR_VALID_NOT_IATI = load_as_string('valid_not_iati')
-"""A string containing valid XML that is not valid against the IATI schema."""
-XML_STR_VALID_IATI = load_as_string('valid_iati')
-"""A string containing valid IATI XML."""
-XML_STR_VALID_IATI_INVALID_CODE = load_as_string('valid_iati_invalid_code')
-"""A string containing valid IATI XML, but an invalid Code valid."""
-XML_STR_INVALID = load_as_string('invalid')
-"""A string that is not valid XML."""
-
-XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT = load_as_string('invalid_iati_missing_required_element')
-"""A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
-XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON = load_as_string('invalid_iati_missing_required_element_from_common')
-"""A string containing invalid IATI XML. It is invalid due to a missing element defined as require in iati-common.xsd"""
-
-XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON = load_as_string('valid_iati_valid_code_from_common')
-"""A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value on the appropriate Codelist."""
-XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON = load_as_string('valid_iati_invalid_code_from_common')
-"""A string containing valid IATI XML containing an element that is defined in iati-common.xsd - it has an attribute with a value that is not on the appropriate Codelist."""
-
-XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT = load_as_string('valid_iati_vocab_default_explicit')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT = load_as_string('valid_iati_vocab_default_implicit')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE = load_as_string('valid_iati_vocab_default_implicit_invalid_code')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Implicitly assumes default vocab and uses code not in list."""
-XML_STR_VALID_IATI_VOCAB_NON_DEFAULT = load_as_string('valid_iati_vocab_non_default')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Explicitly defines non-default vocab and uses code from that list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED = load_as_string('valid_iati_vocab_user_defined')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. No URI specified."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE = load_as_string('valid_iati_vocab_user_defined_with_uri_readable')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code from this list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE = load_as_string('valid_iati_vocab_user_defined_with_uri_readable_bad_code')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and machine readable. Uses code not in list."""
-XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE = load_as_string('valid_iati_vocab_user_defined_with_uri_unreadable')
-"""A string containing valid IATI XML containing an element that uses vocabularies. Specifies user-defined vocabulary. URI specified and not machine readable."""
-
-XML_TREE_VALID = etree.fromstring(XML_STR_VALID_NOT_IATI)
+XML_TREE_VALID = etree.fromstring(load_as_string('valid_not_iati'))
 """An etree that is not valid IATI data."""
-XML_TREE_VALID_IATI = etree.fromstring(XML_STR_VALID_IATI)
+XML_TREE_VALID_IATI = etree.fromstring(load_as_string('valid_iati'))
 """A valid IATI etree."""
-XML_TREE_VALID_IATI_INVALID_CODE = etree.fromstring(XML_STR_VALID_IATI_INVALID_CODE)
+XML_TREE_VALID_IATI_INVALID_CODE = etree.fromstring(load_as_string('valid_iati_invalid_code'))
 """A valid IATI etree that has an invalid Code value."""
 
 TYPE_TEST_DATA = {

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -6,7 +6,7 @@ Example:
     To load a file into a string::
 
         name_of_file = 'a-file-name-without-the-extension'
-        CONSTANT_NAME = _load_as_string(name_of_file))
+        CONSTANT_NAME = _load_as_string(name_of_file)
 
 Note:
     The current method of managing test data is known to be sub-optimal. Suggestions for better methods that satisfy requirements are appreciated!

--- a/iati/tests/test_validate.py
+++ b/iati/tests/test_validate.py
@@ -13,35 +13,35 @@ class TestValidate(object):
 
     def test_basic_validation_valid(self):
         """Perform a super simple data validation against a valid activity Dataset."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid(self):
         """Perform a super simple data validation against an invalid activity Dataset."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_NOT_IATI)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element(self):
         """Perform a super simple data validation against an activity Dataset that is invalid due to a missing required element."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('invalid_iati_missing_required_element'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_invalid_missing_required_element_from_common(self):
         """Perform a super simple data validation against an activity Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_INVALID_IATI_MISSING_REQUIRED_ELEMENT_COMMON)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('invalid_iati_missing_required_element_from_common'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
 
         assert not iati.validate.is_valid(data, schema)
 
     def test_basic_validation_codelist_valid(self):
         """Perform data validation against valid IATI activity XML that has valid Codelist values."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
@@ -51,7 +51,7 @@ class TestValidate(object):
 
     def test_basic_validation_codelist_invalid(self):
         """Perform data validation against valid IATI activity XML that has invalid Codelist values."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_invalid_code'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['Version']
 
@@ -61,7 +61,7 @@ class TestValidate(object):
 
     def test_basic_validation_codelist_valid_from_common(self):
         """Perform data validation against valid IATI activity XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VALID_CODE_FROM_COMMON)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_valid_code_from_common'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
@@ -71,7 +71,7 @@ class TestValidate(object):
 
     def test_basic_validation_codelist_invalid_from_common(self):
         """Perform data validation against valid IATI activity XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_INVALID_CODE_FROM_COMMON)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_invalid_code_from_common'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist = iati.core.default.codelists()['OrganisationType']
 
@@ -81,7 +81,7 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_default_implicit(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been implicitly set."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_default_explicit'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -95,7 +95,7 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_default_implicit_invalid_code(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been implicitly set. The code is invalid."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_IMPLICIT_INVALID_CODE)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_default_implicit'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -109,7 +109,7 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_default_explicit(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been explicitly set as the default value."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_DEFAULT_EXPLICIT)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_default_explicit'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -123,7 +123,7 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_non_default(self):
         """Perform data validation against valid IATI activity XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_NON_DEFAULT)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_non_default'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -137,7 +137,7 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_user_defined(self):
         """Perform data validation against valid IATI activity XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -151,7 +151,7 @@ class TestValidate(object):
 
     def test_validation_codelist_vocab_user_defined_with_uri_readable(self):
         """Perform data validation against valid IATI activity XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined_with_uri_readable'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -169,7 +169,7 @@ class TestValidate(object):
         Todo:
             Check that this is a legitimate check to be performed, given the contents and guidance given in the Standard.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_READABLE_BAD_CODE)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined_with_uri_readable_bad_code'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']
@@ -187,7 +187,7 @@ class TestValidate(object):
         Todo:
             Remove xfail and work on functionality to fully fetch and parse user-defined codelists after higher priority functionality is finished.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.XML_STR_VALID_IATI_VOCAB_USER_DEFINED_WITH_URI_UNREADABLE)
+        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined_with_uri_unreadable'))
         schema = iati.core.ActivitySchema(name=iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID)
         codelist_1 = iati.core.default.codelists()['SectorVocabulary']
         codelist_2 = iati.core.default.codelists()['Sector']


### PR DESCRIPTION
The addition of a helper function makes the file a fair bit clearer due to a reduction in repeated calls to functions with long names.