### PR TITLE
Make date_order rule work in 2.7

### DIFF
--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -370,8 +370,8 @@ class RuleDateOrder(Rule):
             if not dates[0]:
                 return
             # Checks that anything after the YYYY-MM-DD string is a permitted timezone character
-            pattern = re.compile(r'([+-]([01][0-9]|2[0-3]):([0-5][0-9])|Z)?')
-            if (len(set(dates)) == 1) and pattern.fullmatch(dates[0][10:]):
+            pattern = re.compile(r'^([+-]([01][0-9]|2[0-3]):([0-5][0-9])|Z)?$')
+            if (len(set(dates)) == 1) and pattern.match(dates[0][10:]):
                 return datetime.strptime(dates[0][:10], '%Y-%m-%d')
             raise ValueError
 
@@ -382,9 +382,14 @@ class RuleDateOrder(Rule):
             later_date = get_date(context_element, self.more)
 
             try:
+                # python2 allows `bool`s to be compared to `None` without raising a TypeError, while python3 does not
+                if early_date is None or later_date is None:
+                    return None
+
                 if early_date >= later_date:
                     return False
             except TypeError:
+                # a TypeError is raised in python3 if either of the dates is None
                 return None
 
         return True


### PR DESCRIPTION
Python2.7 does not have a fullmatch function for regexes. This is resolved by setting start and end anchors in the regex of interest.

Having fixed the regex problem, it becomes apparent that there is another problem in that None is orderable at v2 but not v3. This is also fixed.