### PR TITLE
Deal with ambiguous NoMoreThanOne case

### DIFF
--- a/iati/core/resources/test_data/202/invalid_nomorethanone.xml
+++ b/iati/core/resources/test_data/202/invalid_nomorethanone.xml
@@ -33,4 +33,6 @@
   </nest>
   <element15></element15><!--multiple paths, single elements-->
   <element16></element16>
+  <element17 attribute=""></element17><!--multiple paths, single attributes-->
+  <element18 attribute=""></element18>
 </root_element>

--- a/iati/core/resources/test_data/202/invalid_nomorethanone.xml
+++ b/iati/core/resources/test_data/202/invalid_nomorethanone.xml
@@ -31,4 +31,6 @@
     <element14 attribute=""></element14><!--nested duplicates-->
     <element14 attribute=""></element14>
   </nest>
+  <element15></element15><!--multiple paths, single elements-->
+  <element16></element16>
 </root_element>

--- a/iati/core/resources/test_data/202/valid_nomorethanone.xml
+++ b/iati/core/resources/test_data/202/valid_nomorethanone.xml
@@ -3,12 +3,10 @@
 <root_element>
   <condition></condition><!--condition case-->
   <element1></element1><!--single path-->
-  <element2></element2><!--multiple paths-->
-  <element3></element3>
+  <element2></element2><!--multiple paths, only one exists-->
   <element4></element4><!--duplicate paths-->
   <element5 attribute=""></element5><!--single path-->
-  <element6 attribute=""></element6><!--multiple paths-->
-  <element7 attribute=""></element7>
+  <element6 attribute=""></element6><!--multiple paths, only one exists-->
   <element8 attribute=""></element8><!--duplicate paths-->
   <nest>
     <element9></element9><!--nested element-->

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -536,20 +536,18 @@ class RuleNoMoreThanOne(Rule):
 
         """
         context_elements = self._find_context_elements(dataset)
-        paths = set(self.paths)
-        compliant_paths = list()
-        no_of_paths = 0
+        unique_paths = set(self.paths)
 
         for context_element in context_elements:
             if self._condition_met_for(context_element):
                 return None
-            no_of_paths += len(paths)
-            for path in paths:
-                results = context_element.xpath(path)
-                if len(results) <= 1:
-                    compliant_paths.append(path)
 
-        return len(compliant_paths) == no_of_paths
+            for path in unique_paths:
+                results = context_element.xpath(path)
+                if len(results) > 1:
+                    return False
+
+        return True
 
 
 class RuleRegexMatches(Rule):

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -542,10 +542,14 @@ class RuleNoMoreThanOne(Rule):
             if self._condition_met_for(context_element):
                 return None
 
+            found_elements = 0
+
             for path in unique_paths:
                 results = context_element.xpath(path)
-                if len(results) > 1:
-                    return False
+                found_elements += len(results)
+
+            if found_elements > 1:
+                return False
 
         return True
 

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -715,7 +715,8 @@ class TestRuleNoMoreThanOne(RuleSubclassTestBase):
         {'paths': ['element10/@attribute', 'element10/@attribute']},
         {'paths': ['element5', 'element6']},  # one path valid, another invalid
         {'paths': ['element11/@attribute', 'element12/@attribute']},
-        {'paths': ['element15', 'element16']}  # multiple paths, one of each
+        {'paths': ['element15', 'element16']},  # multiple paths, one of each
+        {'paths': ['element17/@attribute', 'element18/@attribute']}  # multiple paths, one of each
     ]
 
     @pytest.fixture

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -709,12 +709,13 @@ class TestRuleNoMoreThanOne(RuleSubclassTestBase):
     invalidating_cases = [
         {'paths': ['element1']},  # single path
         {'paths': ['element7/@attribute']},
-        {'paths': ['element2', 'element3']},  # multiple paths
+        {'paths': ['element2', 'element3']},  # multiple paths, multiple of each
         {'paths': ['element8/@attribute', 'element9/@attribute']},
         {'paths': ['element4', 'element4']},  # duplicate paths
         {'paths': ['element10/@attribute', 'element10/@attribute']},
         {'paths': ['element5', 'element6']},  # one path valid, another invalid
-        {'paths': ['element11/@attribute', 'element12/@attribute']}
+        {'paths': ['element11/@attribute', 'element12/@attribute']},
+        {'paths': ['element15', 'element16']}  # multiple paths, one of each
     ]
 
     @pytest.fixture


### PR DESCRIPTION
The `no more than one` rule only permits a single element or attribute from anywhere in the list of paths. Having one of each of the paths is not a harsh enough restriction.

`There must be no more than one element described by the given paths.`