### PR TITLE
Add a test to check for required Rule test data

### DIFF
--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -345,6 +345,15 @@ class RuleSubclassTestBase(object):
         with pytest.raises(ValueError):
             rule_constructor(valid_single_context, junk_condition_case)
 
+    def test_subclass_test_required_data_lists(self):
+        """Check that Rule subclass test classes define the required test data lists."""
+        assert len(self.all_valid_cases)
+        assert len(self.instantiating_cases)
+        assert len(self.uninstantiating_cases)
+        assert len(self.invalidating_cases)
+        assert len(self.validating_cases)
+        assert len(self.nest_cases)
+
 
 class TestRuleAtLeastOne(RuleSubclassTestBase):
     """A container for tests relating to RuleAtLeastOne."""


### PR DESCRIPTION
Based on my understanding of the code, these lists should be present for each of the test subclasses.

Since they're required, a test should be added to make sure they exist. This adds the test.