### PR TITLE
Test no context rules

### DIFF
--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -382,6 +382,9 @@ class RuleAtLeastOne(Rule):
         """
         context_elements = self._find_context_elements(dataset)
 
+        if not len(context_elements):
+            return True
+
         for context_element in context_elements:
             if self._condition_met_for(context_element):
                 return None

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -207,6 +207,11 @@ class RuleSubclassTestBase(object):
         """Return a valid context with multiple matches."""
         return '//nest'
 
+    @pytest.fixture
+    def non_existent_context(self):
+        """Return a valid context with multiple matches."""
+        return '//non-existent-context'
+
     @pytest.fixture(params=[
         'count(condition)>0',
         'condition'
@@ -354,6 +359,16 @@ class RuleSubclassTestBase(object):
         """Check Rule returns expected result when checking multiple contexts."""
         rule = rule_constructor(valid_multiple_context, invalid_nest_case)
         assert not rule.is_valid_for(invalid_dataset)
+
+    def test_non_existent_context_is_valid_for(self, non_existent_context, valid_nest_case, rule_constructor, valid_dataset):
+        """Check Rule returns expected result when checking multiple contexts."""
+        rule = rule_constructor(non_existent_context, valid_nest_case)
+        assert rule.is_valid_for(valid_dataset)
+
+    def test_non_existent_context_is_invalid_for(self, non_existent_context, invalid_nest_case, rule_constructor, invalid_dataset):
+        """Check Rule returns expected result when checking multiple contexts."""
+        rule = rule_constructor(non_existent_context, invalid_nest_case)
+        assert rule.is_valid_for(invalid_dataset)
 
     def test_condition_case_is_True_for_valid_dataset(self, valid_condition_rule, valid_dataset):
         """Check that if a condition is `True`, the rule returns None which is considered equivalent to skipping."""

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -209,7 +209,7 @@ class RuleSubclassTestBase(object):
 
     @pytest.fixture
     def non_existent_context(self):
-        """Return a valid context with multiple matches."""
+        """Return an XPath for a context that does not exist."""
         return '//non-existent-context'
 
     @pytest.fixture(params=[


### PR DESCRIPTION
When a context does not exist, Rules should be `True`.

This was not the case with `AtLeastOne` due to it having inverted logic in comparison to other Rules.