### PR TITLE
Fix some find+replace sillyness in `test_data.py`

### DIFF
--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -298,6 +298,7 @@ def load_as_dataset(path):
         Should raise Exceptions when there are problems loading the requested data.
 
     Raises:
+        FileNotFoundError: When a file at the specified path does not exist.
         ValueError: When a file at the specified path does not contain valid XML.
 
     Todo:
@@ -317,6 +318,9 @@ def load_as_bytes(path):
     Returns:
         bytes: The contents of the file at the specified location.
 
+    Raises:
+        FileNotFoundError: When a file at the specified path does not exist.
+
     Todo:
         Should raise Exceptions when there are problems loading the requested data.
         Add error handling for when the specified file does not exist.
@@ -334,6 +338,9 @@ def load_as_string(path):
 
     Returns:
         str (python3) / unicode (python2): The contents of the file at the specified location.
+
+    Raises:
+        FileNotFoundError: When a file at the specified path does not exist.
 
     Todo:
         Should raise Exceptions when there are problems loading the requested data.

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -322,7 +322,7 @@ def load_as_bytes(path):
         FileNotFoundError: When a file at the specified path does not exist.
 
     Todo:
-        Should raise Exceptions when there are problems loading the requested data.
+        Ensure all reasonably possible OSErrors are documented here and in functions that call this.
         Add error handling for when the specified file does not exist.
         Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).
 
@@ -343,7 +343,6 @@ def load_as_string(path):
         FileNotFoundError: When a file at the specified path does not exist.
 
     Todo:
-        Should raise Exceptions when there are problems loading the requested data.
         Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).
 
     """

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -298,7 +298,7 @@ def load_as_dataset(path):
         Should raise Exceptions when there are problems loading the requested data.
 
     Raises:
-        FileNotFoundError: When a file at the specified path does not exist.
+        FileNotFoundError (python3) / IOError (python2): When a file at the specified path does not exist.
         ValueError: When a file at the specified path does not contain valid XML.
 
     Todo:
@@ -319,7 +319,7 @@ def load_as_bytes(path):
         bytes: The contents of the file at the specified location.
 
     Raises:
-        FileNotFoundError: When a file at the specified path does not exist.
+        FileNotFoundError (python3) / IOError (python2): When a file at the specified path does not exist.
 
     Todo:
         Ensure all reasonably possible OSErrors are documented here and in functions that call this.
@@ -340,7 +340,7 @@ def load_as_string(path):
         str (python3) / unicode (python2): The contents of the file at the specified location.
 
     Raises:
-        FileNotFoundError: When a file at the specified path does not exist.
+        FileNotFoundError (python3) / IOError (python2): When a file at the specified path does not exist.
 
     Todo:
         Pass in PACKAGE as a default parameter, so that this code can be used by other library modules (e.g. iati.fetch).

--- a/iati/core/resources.py
+++ b/iati/core/resources.py
@@ -297,6 +297,9 @@ def load_as_dataset(path):
     Warning:
         Should raise Exceptions when there are problems loading the requested data.
 
+    Raises:
+        ValueError: When a file at the specified path does not contain valid XML.
+
     Todo:
         Add error handling for when the specified file does not exist.
 

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -19,7 +19,7 @@ class TestDatasets(object):
     @pytest.fixture
     def dataset_initialised(self):
         """Return an initialised dataset to work from in other tests."""
-        return iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati'))
+        return iati.core.tests.utilities.load_as_dataset('valid_not_iati')
 
     def test_dataset_no_params(self):
         """Test Dataset creation with no parameters."""
@@ -239,14 +239,12 @@ class TestDatasetSourceFinding(object):
     """A container for tests relating to finding source context within a Dataset."""
 
     @pytest.fixture(params=[
-        iati.core.tests.utilities.load_as_string('valid_not_iati'),
-        iati.core.tests.utilities.load_as_string('valid_iati')
+        iati.core.tests.utilities.load_as_dataset('valid_not_iati'),
+        iati.core.tests.utilities.load_as_dataset('valid_iati')
     ])
     def data(self, request):
         """A Dataset to test."""
-        xml_str = request.param.strip()
-
-        return iati.core.Dataset(xml_str)
+        return request.param
 
     @pytest.fixture
     def split_xml_str(self, data):
@@ -274,7 +272,7 @@ class TestDatasetSourceFinding(object):
 
         Ensure that the line numbers from which source is being returned are the same ones provided by the `sourceline` attribute from tree elements.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati').strip())
+        data = iati.core.tests.utilities.load_as_dataset('valid_not_iati')
         split_xml_str = [''] + data.xml_str.split('\n')
         line_num = line_el_pair['line']
         el_from_tree = data.xml_tree.xpath(line_el_pair['el'])[0]

--- a/iati/core/tests/test_data.py
+++ b/iati/core/tests/test_data.py
@@ -30,17 +30,19 @@ class TestDatasets(object):
 
     def test_dataset_valid_xml_string(self):
         """Test Dataset creation with a valid XML string that is not IATI data."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati'))
+        xml_str = iati.core.tests.utilities.load_as_string('valid_not_iati')
+        data = iati.core.Dataset(xml_str)
 
-        assert data.xml_str == iati.core.tests.utilities.load_as_string('valid_not_iati').strip()
+        assert data.xml_str == xml_str.strip()
         assert etree.tostring(data.xml_tree) == etree.tostring(iati.core.tests.utilities.XML_TREE_VALID)
 
     def test_dataset_xml_string_leading_whitespace(self):
         """Test Dataset creation with a valid XML string that is not IATI data."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('leading_whitespace_xml'))
-        tree = etree.fromstring(iati.core.tests.utilities.load_as_string('leading_whitespace_xml').strip())
+        xml_str = iati.core.tests.utilities.load_as_string('leading_whitespace_xml')
+        data = iati.core.Dataset(xml_str)
+        tree = etree.fromstring(xml_str.strip())
 
-        assert data.xml_str == iati.core.tests.utilities.load_as_string('leading_whitespace_xml').strip()
+        assert data.xml_str == xml_str.strip()
         assert etree.tostring(data.xml_tree) == etree.tostring(tree)
 
     def test_dataset_valid_iati_string(self):
@@ -49,8 +51,10 @@ class TestDatasets(object):
 
     def test_dataset_invalid_xml_string(self):
         """Test Dataset creation with a string that is not valid XML."""
+        xml_str = iati.core.tests.utilities.load_as_string('invalid')
+
         with pytest.raises(ValueError) as excinfo:
-            iati.core.Dataset(iati.core.tests.utilities.load_as_string('invalid'))
+            iati.core.Dataset(xml_str)
 
         assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
@@ -86,17 +90,19 @@ class TestDatasets(object):
             Check that the tree is updated correctly.
 
         """
+        xml_str = iati.core.tests.utilities.load_as_string('valid_not_iati')
         data = dataset_initialised
-        data.xml_str = iati.core.tests.utilities.load_as_string('valid_not_iati')
+        data.xml_str = xml_str
 
-        assert data.xml_str == iati.core.tests.utilities.load_as_string('valid_not_iati').strip()
+        assert data.xml_str == xml_str.strip()
 
     def test_dataset_xml_str_assignment_invalid_str(self, dataset_initialised):
         """Test assignment to the xml_str property with an invalid XML string."""
+        xml_str = iati.core.tests.utilities.load_as_string('invalid')
         data = dataset_initialised
 
         with pytest.raises(ValueError) as excinfo:
-            data.xml_str = iati.core.tests.utilities.load_as_string('invalid')
+            data.xml_str = xml_str
 
         assert str(excinfo.value) == 'The string provided to create a Dataset from is not valid XML.'
 
@@ -142,9 +148,11 @@ class TestDatasets(object):
 
     def test_dataset_xml_tree_assignment_str(self, dataset_initialised):
         """Test assignment to the xml_tree property with an XML string."""
+        xml_str = iati.core.tests.utilities.load_as_string('valid_not_iati')
         data = dataset_initialised
+
         with pytest.raises(TypeError) as excinfo:
-            data.xml_tree = iati.core.tests.utilities.load_as_string('valid_not_iati')
+            data.xml_tree = xml_str
 
         assert 'If setting a dataset with the xml_property, an ElementTree should be provided, not a' in str(excinfo.value)
 
@@ -152,23 +160,25 @@ class TestDatasets(object):
     def test_dataset_xml_tree_assignment_invalid_value(self, dataset_initialised, invalid_value):
         """Test assignment to the xml_tree property with a value that is very much not valid."""
         data = dataset_initialised
+
         with pytest.raises(TypeError) as excinfo:
             data.xml_tree = invalid_value
+
         assert 'If setting a dataset with the xml_property, an ElementTree should be provided, not a' in str(excinfo.value)
 
     def test_instantiation_dataset_from_string(self):
         """Test that a dataset instantiated directly from a string (rather than a file) correctly creates an iati.core.data.Dataset and the input data is contained within the object."""
-        xml = """<?xml version="1.0"?>
+        xml_str = """<?xml version="1.0"?>
         <iati-activities version="xx">
           <iati-activity>
              <iati-identifier></iati-identifier>
          </iati-activity>
         </iati-activities>"""
 
-        dataset = iati.core.data.Dataset(xml)
+        dataset = iati.core.data.Dataset(xml_str)
 
         assert isinstance(dataset, iati.core.data.Dataset)
-        assert dataset.xml_str == xml
+        assert dataset.xml_str == xml_str
 
     @pytest.mark.parametrize("encoding", ["UTF-8", "utf-8", "UTF-16", "utf-16",
                                           "ASCII", "ISO-8859-1", "ISO-8859-2",
@@ -181,13 +191,13 @@ class TestDatasets(object):
             UTF-32 is deliberately omitted as this causes an error: lxml.etree.XMLSyntaxError: Document is empty
 
         """
-        xml = """<?xml version="1.0" encoding="{}"?>
+        base_xml_str = """<?xml version="1.0" encoding="{}"?>
         <iati-activities version="xx">
           <iati-activity>
              <iati-identifier></iati-identifier>
          </iati-activity>
         </iati-activities>""".format(encoding)
-        xml_encoded = xml.encode(encoding)  # Encode the whole string in line with the specified encoding
+        xml_encoded = base_xml_str.encode(encoding)  # Encode the whole string in line with the specified encoding
 
         dataset = iati.core.data.Dataset(xml_encoded)
 
@@ -211,13 +221,13 @@ class TestDatasets(object):
             Amend error message, when the todo in iati.core.data.Dataset.xml_str() has been resolved.
 
         """
-        xml = """<?xml version="1.0" encoding="{}"?>
+        base_xml_str = """<?xml version="1.0" encoding="{}"?>
         <iati-activities version="xx">
           <iati-activity>
              <iati-identifier></iati-identifier>
          </iati-activity>
         </iati-activities>""".format(encoding_declared)
-        xml_encoded = xml.encode(encoding_used)  # Encode the whole string in line with the specified encoding
+        xml_encoded = base_xml_str.encode(encoding_used)  # Encode the whole string in line with the specified encoding
 
         with pytest.raises(ValueError) as excinfo:
             _ = iati.core.data.Dataset(xml_encoded)

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -133,6 +133,13 @@ class TestResources(object):
         assert isinstance(result, iati.core.Dataset)
         assert '<?xml version="1.0"?>\n\n<iati-activities version="2.02">' in result.xml_str
 
+    def test_load_as_dataset_invalid(self):
+        """Test that resources.load_as_dataset raises an error when the provided path does not lead to a file containing valid XML."""
+        path_test_data = iati.core.resources.get_test_data_path('invalid')
+
+        with pytest.raises(ValueError):
+            _ = iati.core.resources.load_as_dataset(path_test_data)
+
     def test_load_as_string(self):
         """Test that resources.load_as_string returns a string (python3) or unicode (python2) object with the expected content."""
         path_test_data = iati.core.resources.get_test_data_path('invalid')

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -149,6 +149,14 @@ class TestResources(object):
         assert isinstance(result, six.string_types)
         assert result == 'This is a string that is not valid XML\n'
 
+    @pytest.mark.parametrize("load_method", [iati.core.resources.load_as_bytes, iati.core.resources.load_as_dataset, iati.core.resources.load_as_string])
+    def test_load_as_x_non_existing_file(self, load_method):
+        """Test that resources.load_as_bytes returns a bytes object with the expected content."""
+        path_test_data = iati.core.resources.get_test_data_path('this-file-does-not-exist')
+
+        with pytest.raises(FileNotFoundError):
+            _ = load_method(path_test_data)
+
     def test_resource_filename(self):
         """Check that resource file names are found correctly.
 

--- a/iati/core/tests/test_resources.py
+++ b/iati/core/tests/test_resources.py
@@ -154,6 +154,12 @@ class TestResources(object):
         """Test that resources.load_as_bytes returns a bytes object with the expected content."""
         path_test_data = iati.core.resources.get_test_data_path('this-file-does-not-exist')
 
+        # python 2/3 compatibility - FileNotFoundError introduced at Python 3
+        try:
+            FileNotFoundError
+        except NameError:
+            FileNotFoundError = IOError
+
         with pytest.raises(FileNotFoundError):
             _ = load_method(path_test_data)
 


### PR DESCRIPTION
In several cases, the same function call was being called multiple times when it didn't need to be. This is due to the values previously being a constant, then find+replace happening.

Something similar will likely need doing in other files, though this appears to be all that's in `dev` at present.