### PR TITLE
Refactor test_validator.py to use test util functions

### DIFF
--- a/iati/tests/test_validator.py
+++ b/iati/tests/test_validator.py
@@ -282,41 +282,38 @@ class ValidationTestBase(object):
         return ''
 
     @pytest.fixture(params=[
-         iati.core.tests.utilities.load_as_string('valid_iati'),
-         iati.core.tests.utilities.load_as_string('valid_iati_invalid_code')
+         iati.core.tests.utilities.load_as_dataset('valid_iati'),
+         iati.core.tests.utilities.load_as_dataset('valid_iati_invalid_code')
     ])
     def iati_dataset(self, request):
         """A Dataset that is valid against the IATI Schema."""
-        return iati.core.Dataset(request.param)
+        return request.param
 
     @pytest.fixture(params=[
-         iati.core.tests.utilities.load_as_string('valid_not_iati')
+         iati.core.tests.utilities.load_as_dataset('valid_not_iati')
     ])
     def not_iati_dataset(self, request):
         """A Dataset that is not valid against the IATI Schema."""
-        return iati.core.Dataset(request.param)
+        return request.param
 
     @pytest.fixture(params=[
-        iati.core.tests.utilities.load_as_string('invalid_iati_missing_required_element'),
-        iati.core.tests.utilities.load_as_string('invalid_iati_missing_required_element_from_common')
+        iati.core.tests.utilities.load_as_dataset('invalid_iati_missing_required_element'),
+        iati.core.tests.utilities.load_as_dataset('invalid_iati_missing_required_element_from_common')
     ])
     def not_iati_dataset_missing_required_el(self, request):
         """A Dataset that is not valid against the IATI Schema because it is missing a required element."""
-        return iati.core.Dataset(request.param)
+        return request.param
 
     @pytest.fixture(params=iati.core.resources.get_test_data_paths_in_folder('ssot-activity-xml-pass'))
     def iati_dataset_valid_from_ssot(self, request):
         """A `should-pass` Dataset from the SSOT."""
-        xml_str = iati.core.resources.load_as_string(request.param)
-
+        return iati.core.resources.load_as_dataset(request.param)
         return iati.core.Dataset(xml_str)
 
     @pytest.fixture(params=iati.core.resources.get_test_data_paths_in_folder('ssot-activity-xml-fail'))
     def iati_dataset_invalid_from_ssot(self, request):
         """A `should-fail` Dataset from the SSOT."""
-        xml_str = iati.core.resources.load_as_string(request.param)
-
-        return iati.core.Dataset(xml_str)
+        return iati.core.resources.load_as_dataset(request.param)
 
 
 class ValidateCodelistsBase(ValidationTestBase):
@@ -397,7 +394,7 @@ class TestValidationTruthyIATI(ValidationTestBase):
 
     def test_basic_validation_valid(self, schema_basic):
         """Perform a super simple data validation against a valid Dataset."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_basic)
@@ -412,7 +409,7 @@ class TestValidationTruthyIATI(ValidationTestBase):
 
     def test_basic_validation_invalid(self, schema_basic):
         """Perform a super simple data validation against an invalid Dataset."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_not_iati'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_not_iati')
 
         assert iati.validator.is_xml(data.xml_str)
         assert not iati.validator.is_iati_xml(data, schema_basic)
@@ -427,7 +424,7 @@ class TestValidationTruthyIATI(ValidationTestBase):
 
     def test_basic_validation_invalid_missing_required_element(self, schema_basic):
         """Perform a super simple data validation against a Dataset that is invalid due to a missing required element."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('invalid_iati_missing_required_element'))
+        data = iati.core.tests.utilities.load_as_dataset('invalid_iati_missing_required_element')
 
         assert iati.validator.is_xml(data.xml_str)
         assert not iati.validator.is_iati_xml(data, schema_basic)
@@ -435,7 +432,7 @@ class TestValidationTruthyIATI(ValidationTestBase):
 
     def test_basic_validation_invalid_missing_required_element_from_common(self, schema_basic):
         """Perform a super simple data validation against a Dataset that is invalid due to a missing required element that is defined in iati-common.xsd."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('invalid_iati_missing_required_element_from_common'))
+        data = iati.core.tests.utilities.load_as_dataset('invalid_iati_missing_required_element_from_common')
 
         assert iati.validator.is_xml(data.xml_str)
         assert not iati.validator.is_iati_xml(data, schema_basic)
@@ -634,7 +631,7 @@ class TestIsValidIATIXML(ValidationTestBase):
 
     def test_iati_xml_from_ssot_valid(self, schema_basic):
         """Perform check to see whether valid XML from the SSOT can be loaded and validated."""
-        data = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('ssot-activity-xml-pass/location/01-generic-location'))
+        data = iati.core.tests.utilities.load_as_dataset('ssot-activity-xml-pass/location/01-generic-location')
 
         result = iati.validator.validate_is_iati_xml(data, schema_basic)
 
@@ -642,7 +639,7 @@ class TestIsValidIATIXML(ValidationTestBase):
 
     def test_iati_xml_from_ssot_invalid(self, schema_basic):
         """Perform check to see whether invalid XML from the SSOT can be loaded and validated."""
-        data = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('ssot-activity-xml-fail/other-identifier/01-missing-attribute-type'))
+        data = iati.core.tests.utilities.load_as_dataset('ssot-activity-xml-fail/other-identifier/01-missing-attribute-type')
 
         result = iati.validator.validate_is_iati_xml(data, schema_basic)
 
@@ -655,7 +652,7 @@ class TestValidationCodelist(ValidateCodelistsBase):
 
     def test_basic_validation_codelist_valid(self, schema_version):
         """Perform data validation against valid IATI XML that has valid Codelist values."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_version)
@@ -663,7 +660,7 @@ class TestValidationCodelist(ValidateCodelistsBase):
 
     def test_basic_validation_codelist_invalid(self, schema_version):
         """Perform data validation against valid IATI XML that has invalid Codelist values."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_invalid_code'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_invalid_code')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_version)
@@ -671,7 +668,7 @@ class TestValidationCodelist(ValidateCodelistsBase):
 
     def test_basic_validation_codelist_valid_from_common(self, schema_org_type):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested is on an element defined in common.xsd."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_valid_code_from_common'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_valid_code_from_common')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
@@ -679,7 +676,7 @@ class TestValidationCodelist(ValidateCodelistsBase):
 
     def test_basic_validation_codelist_invalid_from_common(self, schema_org_type):
         """Perform data validation against valid IATI XML that has invalid Codelist values. The attribute being tested is on an element defined in common.xsd."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_invalid_code_from_common'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_invalid_code_from_common')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
@@ -687,24 +684,22 @@ class TestValidationCodelist(ValidateCodelistsBase):
 
     def test_basic_validation_codes_valid_multi_use_codelist(self, schema_org_type):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attributes being tested are under different elements, but require the same Codelist."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_valid_codes_multiple_xpaths_for_codelist'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_valid_codes_multiple_xpaths_for_codelist')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
         assert iati.validator.is_valid(data, schema_org_type)
 
-    @pytest.mark.parametrize("xml_str", [iati.core.tests.utilities.load_as_string('valid_iati_invalid_codes_multiple_xpaths_for_codelist_first'), iati.core.tests.utilities.load_as_string('valid_iati_invalid_codes_multiple_xpaths_for_codelist_second')])
-    def test_basic_validation_codes_invalid_multi_use_codelist(self, xml_str, schema_org_type):
+    @pytest.mark.parametrize("data", [iati.core.tests.utilities.load_as_dataset('valid_iati_invalid_codes_multiple_xpaths_for_codelist_first'), iati.core.tests.utilities.load_as_dataset('valid_iati_invalid_codes_multiple_xpaths_for_codelist_second')])
+    def test_basic_validation_codes_invalid_multi_use_codelist(self, data, schema_org_type):
         """Perform data validation against valid IATI XML that has invalid Codelist values. The attributes being tested are under different elements, but require the same Codelist."""
-        data = iati.core.Dataset(xml_str)
-
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_org_type)
         assert not iati.validator.is_valid(data, schema_org_type)
 
     def test_basic_validation_codelist_incomplete_present(self, schema_incomplete_codelist):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_incomplete_codelist_code_present'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_incomplete_codelist_code_present')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_incomplete_codelist)
@@ -712,7 +707,7 @@ class TestValidationCodelist(ValidateCodelistsBase):
 
     def test_basic_validation_codelist_incomplete_not_present(self, schema_incomplete_codelist):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is not on the list."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_incomplete_codelist_code_not_present'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_incomplete_codelist_code_not_present')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_incomplete_codelist)
@@ -725,7 +720,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
 
     def test_validation_codelist_vocab_default_implicit(self, schema_sectors):
         """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_default_implicit'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_default_implicit')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -733,7 +728,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
 
     def test_validation_codelist_vocab_default_implicit_invalid_code(self, schema_sectors):
         """Perform data validation against valid IATI XML with a vocabulary that has been implicitly set. The code is invalid."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_default_implicit_invalid_code'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_default_implicit_invalid_code')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -741,7 +736,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
 
     def test_validation_codelist_vocab_default_explicit(self, schema_sectors):
         """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as the default value."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_default_explicit'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_default_explicit')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -749,7 +744,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
 
     def test_validation_codelist_vocab_non_default(self, schema_sectors):
         """Perform data validation against valid IATI XML with a vocabulary that has been explicitly set as a valid non-default value. The code is valid against this non-default vocabulary."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_non_default'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_non_default')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -762,7 +757,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         The codes are valid against the vocabularies.
         Percentages add up to 100.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_multiple_same_valid'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_multiple_same_valid')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -775,7 +770,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         The codes are valid against the vocabularies.
         Percentages add up to 100.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_multiple_different_valid'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_multiple_different_valid')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -788,7 +783,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         The codes are valid against the vocabularies.
         Percentages add up to 100.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_multiple_same_invalid_code'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_multiple_same_invalid_code')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -801,7 +796,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         The codes are valid against the vocabularies.
         Percentages add up to 100.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_multiple_different_invalid_code'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_multiple_different_invalid_code')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -809,7 +804,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
 
     def test_validation_codelist_vocab_user_defined(self, schema_sectors):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. No URI is defined, so the code cannot be checked."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_user_defined')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -818,7 +813,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
     @pytest.mark.skip(reason="Not yet implemented - need to be able to load Codelists from URLs")
     def test_validation_codelist_vocab_user_defined_with_uri_readable(self, schema_sectors):
         """Perform data validation against valid IATI XML with a user-defined vocabulary. A URI is defined, and points to a machine-readable codelist. As such, the code can be checked. The @code is valid."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined_with_uri_readable'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_user_defined_with_uri_readable')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -831,7 +826,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         Todo:
             Check that this is a legitimate check to be performed, given the contents and guidance given in the Standard.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined_with_uri_readable_bad_code'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_user_defined_with_uri_readable_bad_code')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -844,7 +839,7 @@ class TestValidationVocabularies(ValidateCodelistsBase):
         Todo:
             Remove xfail and work on functionality to fully fetch and parse user-defined codelists after higher priority functionality is finished.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_vocab_user_defined_with_uri_unreadable'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_vocab_user_defined_with_uri_unreadable')
 
         assert iati.validator.is_xml(data.xml_str)
         assert iati.validator.is_iati_xml(data, schema_sectors)
@@ -856,7 +851,7 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
 
     def test_basic_validation_codelist_valid_detailed_output(self, schema_version):
         """Perform data validation against valid IATI XML that has valid Codelist values.  Obtain detailed error output."""
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati')
 
         assert iati.validator.full_validation(data, schema_version) == iati.validator.ValidationErrorLog()
 
@@ -879,7 +874,7 @@ class TestValidatorFullValidation(ValidateCodelistsBase):
         """Perform data validation against valid IATI XML that has valid Codelist values. The attribute being tested refers to an incomplete Codelist. The value is on the list.
         Obtain detailed error output.
         """
-        data = iati.core.Dataset(iati.core.tests.utilities.load_as_string('valid_iati_incomplete_codelist_code_present'))
+        data = iati.core.tests.utilities.load_as_dataset('valid_iati_incomplete_codelist_code_present')
 
         result = iati.validator.full_validation(data, schema_incomplete_codelist)
 


### PR DESCRIPTION
There is now a load_as_dataset() function. As such, it makes sense to use this where it is necessary to load a Dataset but having access to the original string is not required.