### PR TITLE
Utilise a utility function to simplify constant definitions

### DIFF
--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -20,65 +20,6 @@ from lxml import etree
 import iati.core.resources
 
 
-DATASET_FOR_ATLEASTONE_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_atleastone'))
-"""A Dataset that is permitted by `RuleAtLeastOne`."""
-DATASET_FOR_ATLEASTONE_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_atleastone'))
-"""A Dataset that is not permitted by `RuleAtLeastOne`."""
-
-DATASET_FOR_DATEORDER_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_dateorder'))
-"""A Dataset that is permitted by `RuleDateOrder`."""
-DATASET_FOR_DATEORDER_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_dateorder'))
-"""A Dataset that is not permitted by `RuleDateOrder`."""
-DATASET_FOR_DATEORDER_RULE_INVALID_DATE_FORMAT = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_format_dateorder'))
-"""A Dataset that contains dates that are formatted incorrectly according to RuleDateOrder."""
-
-DATASET_FOR_DEPENDENT_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_dependent'))
-"""A Dataset that is permitted by `RuleDependent`."""
-DATASET_FOR_DEPENDENT_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_dependent'))
-"""A Dataset that is not permitted by `RuleDependent`."""
-
-DATASET_FOR_NOMORETHANONE_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_nomorethanone'))
-"""A Dataset that is permitted by `RuleNoMoreThanOne`."""
-DATASET_FOR_NOMORETHANONE_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_nomorethanone'))
-"""A Dataset that is not permitted by `RuleNoMoreThanOne`."""
-
-DATASET_FOR_REGEXMATCHES_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_regexmatches'))
-"""A Dataset that is permitted by `RuleRegexMatches`."""
-DATASET_FOR_REGEXMATCHES_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_regexmatches'))
-"""A Dataset that is not permitted by `RuleRegexMatches`."""
-
-DATASET_FOR_REGEXNOMATCHES_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_regexnomatches'))
-"""A Dataset that is permitted by `RuleRegexNoMatches`."""
-DATASET_FOR_REGEXNOMATCHES_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_regexnomatches'))
-"""A Dataset that is not permitted by `RuleRegexNoMatches`."""
-
-DATASET_FOR_STARTSWITH_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_startswith'))
-"""A Dataset that is permitted by `RuleStartsWith`."""
-DATASET_FOR_STARTSWITH_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_startswith'))
-"""A Dataset that is not permitted by `RuleStartsWith`."""
-
-DATASET_FOR_SUM_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_sum'))
-"""A Dataset that is permitted by `RuleSum`."""
-DATASET_FOR_SUM_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_sum'))
-"""A Dataset that is not permitted by `RuleSum`."""
-
-DATASET_FOR_UNIQUE_RULE_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_unique'))
-"""A Dataset that is permitted by `RuleUnique`."""
-DATASET_FOR_UNIQUE_RULE_INVALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_unique'))
-"""A Dataset that is not permitted by `RuleUnique`."""
-
-DATASET_FOR_STANDARD_RULESET_VALID = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('valid_std_ruleset'))
-"""A Dataset that meets the IATI Standard ruleset."""
-DATASET_FOR_STANDARD_RULESET_INVALID_BAD_DATE_ORDER = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_std_ruleset_bad_date_order'))
-"""A Dataset that does not meet the IATI Standard ruleset (on account of a bad date order)."""
-DATASET_FOR_STANDARD_RULESET_INVALID_BAD_IDENTIFIER = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_std_ruleset_bad_identifier'))
-"""A Dataset that does not meet the IATI Standard ruleset (on account of a bad IATI identifier)."""
-DATASET_FOR_STANDARD_RULESET_INVALID_DOES_NOT_SUM_100 = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_std_ruleset_does_not_sum_100'))
-"""A Dataset that does not meet the IATI Standard ruleset (on account of a sums not adding to 100%)."""
-DATASET_FOR_STANDARD_RULESET_INVALID_MISSING_SECTOR_ELEMENT = iati.core.resources.load_as_dataset(iati.core.resources.get_test_data_path('invalid_std_ruleset_missing_sector_element'))
-"""A Dataset that does not meet the IATI Standard ruleset (on account of a missing sector element)."""
-
-
 def load_as_dataset(file_path):
     """Load a specified test data file as a Dataset.
 
@@ -106,6 +47,65 @@ def load_as_string(file_path):
 
     """
     return iati.core.resources.load_as_string(iati.core.resources.get_test_data_path(file_path))
+
+
+DATASET_FOR_ATLEASTONE_RULE_VALID = load_as_dataset('valid_atleastone')
+"""A Dataset that is permitted by `RuleAtLeastOne`."""
+DATASET_FOR_ATLEASTONE_RULE_INVALID = load_as_dataset('invalid_atleastone')
+"""A Dataset that is not permitted by `RuleAtLeastOne`."""
+
+DATASET_FOR_DATEORDER_RULE_VALID = load_as_dataset('valid_dateorder')
+"""A Dataset that is permitted by `RuleDateOrder`."""
+DATASET_FOR_DATEORDER_RULE_INVALID = load_as_dataset('invalid_dateorder')
+"""A Dataset that is not permitted by `RuleDateOrder`."""
+DATASET_FOR_DATEORDER_RULE_INVALID_DATE_FORMAT = load_as_dataset('invalid_format_dateorder')
+"""A Dataset that contains dates that are formatted incorrectly according to RuleDateOrder."""
+
+DATASET_FOR_DEPENDENT_RULE_VALID = load_as_dataset('valid_dependent')
+"""A Dataset that is permitted by `RuleDependent`."""
+DATASET_FOR_DEPENDENT_RULE_INVALID = load_as_dataset('invalid_dependent')
+"""A Dataset that is not permitted by `RuleDependent`."""
+
+DATASET_FOR_NOMORETHANONE_RULE_VALID = load_as_dataset('valid_nomorethanone')
+"""A Dataset that is permitted by `RuleNoMoreThanOne`."""
+DATASET_FOR_NOMORETHANONE_RULE_INVALID = load_as_dataset('invalid_nomorethanone')
+"""A Dataset that is not permitted by `RuleNoMoreThanOne`."""
+
+DATASET_FOR_REGEXMATCHES_RULE_VALID = load_as_dataset('valid_regexmatches')
+"""A Dataset that is permitted by `RuleRegexMatches`."""
+DATASET_FOR_REGEXMATCHES_RULE_INVALID = load_as_dataset('invalid_regexmatches')
+"""A Dataset that is not permitted by `RuleRegexMatches`."""
+
+DATASET_FOR_REGEXNOMATCHES_RULE_VALID = load_as_dataset('valid_regexnomatches')
+"""A Dataset that is permitted by `RuleRegexNoMatches`."""
+DATASET_FOR_REGEXNOMATCHES_RULE_INVALID = load_as_dataset('invalid_regexnomatches')
+"""A Dataset that is not permitted by `RuleRegexNoMatches`."""
+
+DATASET_FOR_STARTSWITH_RULE_VALID = load_as_dataset('valid_startswith')
+"""A Dataset that is permitted by `RuleStartsWith`."""
+DATASET_FOR_STARTSWITH_RULE_INVALID = load_as_dataset('invalid_startswith')
+"""A Dataset that is not permitted by `RuleStartsWith`."""
+
+DATASET_FOR_SUM_RULE_VALID = load_as_dataset('valid_sum')
+"""A Dataset that is permitted by `RuleSum`."""
+DATASET_FOR_SUM_RULE_INVALID = load_as_dataset('invalid_sum')
+"""A Dataset that is not permitted by `RuleSum`."""
+
+DATASET_FOR_UNIQUE_RULE_VALID = load_as_dataset('valid_unique')
+"""A Dataset that is permitted by `RuleUnique`."""
+DATASET_FOR_UNIQUE_RULE_INVALID = load_as_dataset('invalid_unique')
+"""A Dataset that is not permitted by `RuleUnique`."""
+
+DATASET_FOR_STANDARD_RULESET_VALID = load_as_dataset('valid_std_ruleset')
+"""A Dataset that meets the IATI Standard ruleset."""
+DATASET_FOR_STANDARD_RULESET_INVALID_BAD_DATE_ORDER = load_as_dataset('invalid_std_ruleset_bad_date_order')
+"""A Dataset that does not meet the IATI Standard ruleset (on account of a bad date order)."""
+DATASET_FOR_STANDARD_RULESET_INVALID_BAD_IDENTIFIER = load_as_dataset('invalid_std_ruleset_bad_identifier')
+"""A Dataset that does not meet the IATI Standard ruleset (on account of a bad IATI identifier)."""
+DATASET_FOR_STANDARD_RULESET_INVALID_DOES_NOT_SUM_100 = load_as_dataset('invalid_std_ruleset_does_not_sum_100')
+"""A Dataset that does not meet the IATI Standard ruleset (on account of a sums not adding to 100%)."""
+DATASET_FOR_STANDARD_RULESET_INVALID_MISSING_SECTOR_ELEMENT = load_as_dataset('invalid_std_ruleset_missing_sector_element')
+"""A Dataset that does not meet the IATI Standard ruleset (on account of a missing sector element)."""
 
 
 SCHEMA_ACTIVITY_NAME_VALID = 'iati-activities-schema'


### PR DESCRIPTION
A single call to a local function is much nicer than a nested call to a pair of functions in a different module