### PR TITLE
'for _, thing in items()' -> 'for thing in values()'

### DIFF
--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -46,7 +46,7 @@ class TestDefault(object):
 
         assert isinstance(codelists, dict)
         assert len(codelists) == 62
-        for _, codelist in codelists.items():
+        for codelist in codelists.values():
             assert isinstance(codelist, iati.core.Codelist)
 
     def test_codelist_mapping_condition(self):
@@ -93,7 +93,7 @@ class TestDefault(object):
 
         assert isinstance(schemas, dict)
         assert len(schemas) == 1
-        for _, schema in schemas.items():
+        for schema in schemas.values():
             assert isinstance(schema, iati.core.ActivitySchema)
 
     def test_default_organisation_schemas(self):
@@ -106,7 +106,7 @@ class TestDefault(object):
 
         assert isinstance(schemas, dict)
         assert len(schemas) == 1
-        for _, schema in schemas.items():
+        for schema in schemas.values():
             assert isinstance(schema, iati.core.OrganisationSchema)
 
     def test_default_schemas(self):

--- a/iati/validator.py
+++ b/iati/validator.py
@@ -491,7 +491,7 @@ def get_error_codes():
     err_codes_dict = { k: v for code in err_codes_list_of_dict for k, v in code.items() }
 
     # convert name of exception into reference to the relevant class
-    for _, err in err_codes_dict.items():
+    for err in err_codes_dict.values():
         # python2/3 have exceptions in different modules, though six and future do not appear to have a standard workaround for this
         try:
             err['base_exception'] = getattr(sys.modules['builtins'], err['base_exception'])


### PR DESCRIPTION
This changes dictionary access to use a more sensible iterator