### PR TITLE
Provide safer and cleaner `iati.core.default` interface

### DIFF
--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -218,36 +218,3 @@ def organisation_schema(version=None):
 
     """
     return _organisation_schema(version)
-
-
-def _schemas(use_cache=False):
-    """Locate all the default IATI Schemas and return them within a dictionary.
-
-    Args:
-        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
-        use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
-
-    Returns:
-        dict: A dictionary containing all the Schemas for versions of the Standard. This returns the name of the Schema (as the key) and a subclass of iati.core.schemas.Schema() (as the value).
-
-    Todo:
-        Consider the Schema that defines the format of Codelists.
-
-    """
-    _activity_schema(use_cache)
-    _organisation_schema(use_cache)
-
-    return _SCHEMAS  # Both activity_schemas and organisation_schemas will update the _SCHEMAS constant.
-
-
-def schemas(version=None):
-    """Locate all the default IATI Schemas and return them within a dictionary.
-
-    Args:
-        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
-
-    Returns:
-        dict: A dictionary containing all the Schemas for versions of the Standard. This returns the name of the Schema (as the key) and a subclass of iati.core.schemas.Schema() (as the value).
-
-    """
-    return _schemas(version)

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -21,13 +21,18 @@ def get_default_version_if_none(version):
     Args:
         version (str / None): The version to test against.
 
+    Raises:
+        ValueError: When the `version` parameter is not a valid version.
+
     Returns:
         str: The default version if the input version is None. Otherwise returns the input version.
+
     """
     if version is None:
         return iati.core.constants.STANDARD_VERSION_LATEST
-    else:
-        return version
+    elif version not in iati.core.constants.STANDARD_VERSIONS:
+        raise ValueError("Version {0} is not a valid version of the IATI Standard.".format(version))
+    return version
 
 
 _CODELISTS = {}

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -152,20 +152,16 @@ def _activity_schema(version=None, use_cache=False):
         dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
 
     """
-    output = {}
-
     version = get_default_version_if_none(version)
 
     activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
-    # import pdb;pdb.set_trace()
+
     if ('iati-activities-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
         if version not in _SCHEMAS.keys():
             _SCHEMAS[version] = {}
         _SCHEMAS[version]['iati-activities-schema'] = iati.core.ActivitySchema(activity_schema_paths[0])
 
-    output[version] = _SCHEMAS[version]['iati-activities-schema']
-
-    return output[version]
+    return _SCHEMAS[version]['iati-activities-schema']
 
 
 def activity_schema(version=None):
@@ -192,19 +188,16 @@ def _organisation_schema(version=None, use_cache=False):
         dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
 
     """
-    output = {}
-
     version = get_default_version_if_none(version)
 
     organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
+
     if ('iati-organisations-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
         if version not in _SCHEMAS.keys():
             _SCHEMAS[version] = {}
         _SCHEMAS[version]['iati-organisations-schema'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
 
-    output[version] = _SCHEMAS[version]['iati-organisations-schema']
-
-    return output[version]
+    return _SCHEMAS[version]['iati-organisations-schema']
 
 
 def organisation_schema(version=None):

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -19,10 +19,10 @@ def get_default_version_if_none(version):
     """Returns the default version number if the input version is None. Otherwise returns the input version as is.
 
     Args:
-        version (str or None): The version to test against.
+        version (str / None): The version to test against.
 
     Returns:
-        str or version: The default version if the input version is None.  Otherwise returns the input version.
+        str: The default version if the input version is None. Otherwise returns the input version.
     """
     if version is None:
         return iati.core.constants.STANDARD_VERSION_LATEST

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -4,9 +4,7 @@ This includes Codelists, Schemas and Rulesets at various versions of the Standar
 
 Todo:
     Handle multiple versions of the Standard rather than limiting to the latest.
-
     Implement more than Codelists.
-
 """
 import os
 from copy import deepcopy
@@ -16,7 +14,7 @@ import iati.core.resources
 
 
 def get_default_version_if_none(version):
-    """Returns the default version number if the input version is None. Otherwise returns the input version as is.
+    """Return the default version number if the input version is None. Otherwise returns the input version as is.
 
     Args:
         version (str / None): The version to test against.

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -141,7 +141,7 @@ Warning:
 """
 
 
-def activity_schemas(use_cache=False):
+def _activity_schemas(use_cache=False):
     """Return a dictionary of the default ActivitySchema objects for all versions of the Standard.
 
     Args:
@@ -164,7 +164,17 @@ def activity_schemas(use_cache=False):
     return output
 
 
-def organisation_schemas(use_cache=False):
+def activity_schemas():
+    """Return a dictionary of the default ActivitySchema objects for all versions of the Standard.
+
+    Returns:
+        dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
+
+    """
+    return _activity_schemas()
+
+
+def _organisation_schemas(use_cache=False):
     """Return a dictionary of the default OrganisationSchema objects for all versions of the Standard.
 
     Args:
@@ -187,7 +197,17 @@ def organisation_schemas(use_cache=False):
     return output
 
 
-def schemas(use_cache=False):
+def organisation_schemas():
+    """Return a dictionary of the default OrganisationSchema objects for all versions of the Standard.
+
+    Returns:
+        dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
+
+    """
+    return _organisation_schemas()
+
+
+def _schemas(use_cache=False):
     """Locate all the default IATI Schemas and return them within a dictionary.
 
     Args:
@@ -200,10 +220,20 @@ def schemas(use_cache=False):
         Consider the Schema that defines the format of Codelists.
 
     """
-    activity_schemas(use_cache)
-    organisation_schemas(use_cache)
+    _activity_schemas(use_cache)
+    _organisation_schemas(use_cache)
 
     return _SCHEMAS  # Both activity_schemas and organisation_schemas will update the _SCHEMAS constant.
+
+
+def schemas():
+    """Locate all the default IATI Schemas and return them within a dictionary.
+
+    Returns:
+        dict: A dictionary containing all the Schemas for versions of the Standard. This returns the name of the Schema (as the key) and a subclass of iati.core.schemas.Schema() (as the value).
+
+    """
+    return _schemas()
 
 
 def schema(name, version=None):

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -38,6 +38,20 @@ _CODELISTS = {}
 
 This removes the need to repeatedly load a Codelist from disk each time it is accessed.
 
+The dictionary is structured as:
+
+{
+    "version_number_a": {
+        "codelist_name_1": iati.core.Codelist(codelist_1),
+        "codelist_name_2": iati.core.Codelist(codelist_2)
+        [...]
+    },
+    "version_number_b": {
+        [...]
+    },
+    [...]
+}
+
 Warning:
     Modifying values directly obtained from this cache can potentially cause unexpected behavior. As such, it is highly recommended to perform a `deepcopy()` on any accessed Codelist before it is modified in any way.
 
@@ -137,6 +151,23 @@ _SCHEMAS = {}
 
 This removes the need to repeatedly load a Schema from disk each time it is accessed.
 
+{
+    "version_number_a": {
+        "populated": {
+            "activity": iati.core.ActivitySchema
+            "organisation": iati.core.OrganisationSchema
+        },
+        "unpopulated": {
+            "activity": iati.core.ActivitySchema
+            "organisation": iati.core.OrganisationSchema
+        },
+    },
+    "version_number_b": {
+        [...]
+    },
+    [...]
+}
+
 Warning:
     Modifying values directly obtained from this cache can potentially cause unexpected behavior. As such, it is highly recommended to perform a `deepcopy()` on any accessed Schema before it is modified in any way.
 
@@ -161,12 +192,14 @@ def _activity_schema(version=None, use_cache=False):
 
     activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
 
-    if ('iati-activities-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
+    if ('activity' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
         if version not in _SCHEMAS.keys():
             _SCHEMAS[version] = {}
-        _SCHEMAS[version]['iati-activities-schema'] = iati.core.ActivitySchema(activity_schema_paths[0])
+        if 'activity' not in _SCHEMAS[version].keys():
+               _SCHEMAS[version]['activity'] = {}
+        _SCHEMAS[version]['activity']['unpopulated'] = iati.core.ActivitySchema(activity_schema_paths[0])
 
-    return _SCHEMAS[version]['iati-activities-schema']
+    return _SCHEMAS[version]['activity']['unpopulated']
 
 
 def activity_schema(version=None):
@@ -203,12 +236,14 @@ def _organisation_schema(version=None, use_cache=False):
 
     organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
 
-    if ('iati-organisations-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
+    if ('organisation' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
         if version not in _SCHEMAS.keys():
             _SCHEMAS[version] = {}
-        _SCHEMAS[version]['iati-organisations-schema'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
+        if 'organisation' not in _SCHEMAS[version].keys():
+           _SCHEMAS[version]['organisation'] = {}
+        _SCHEMAS[version]['organisation']['unpopulated'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
 
-    return _SCHEMAS[version]['iati-organisations-schema']
+    return _SCHEMAS[version]['organisation']['unpopulated']
 
 
 def organisation_schema(version=None):

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -22,7 +22,7 @@ def get_default_version_if_none(version):
         version (str / None): The version to test against.
 
     Raises:
-        ValueError: When the `version` parameter is not a valid version.
+        ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
         str: The default version if the input version is None. Otherwise returns the input version.
@@ -152,6 +152,9 @@ def _activity_schema(version=None, use_cache=False):
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
         use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
 
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
+
     Returns:
         dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
 
@@ -174,6 +177,9 @@ def activity_schema(version=None):
     Args:
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
 
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
+
     Returns:
         dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
 
@@ -187,6 +193,9 @@ def _organisation_schema(version=None, use_cache=False):
     Args:
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
         use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
+
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
         dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
@@ -209,6 +218,9 @@ def organisation_schema(version=None):
 
     Args:
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
+
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
         dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -141,10 +141,11 @@ Warning:
 """
 
 
-def _activity_schemas(use_cache=False):
+def _activity_schema(version=None, use_cache=False):
     """Return a dictionary of the default ActivitySchema objects for all versions of the Standard.
 
     Args:
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
         use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
 
     Returns:
@@ -152,32 +153,39 @@ def _activity_schemas(use_cache=False):
 
     """
     output = {}
-    for version in iati.core.constants.STANDARD_VERSIONS:
-        activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
-        if ('iati-activities-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
-            if version not in _SCHEMAS.keys():
-                _SCHEMAS[version] = {}
-            _SCHEMAS[version]['iati-activities-schema'] = iati.core.ActivitySchema(activity_schema_paths[0])
 
-        output[version] = _SCHEMAS[version]['iati-activities-schema']
+    version = get_default_version_if_none(version)
 
-    return output
+    activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
+    # import pdb;pdb.set_trace()
+    if ('iati-activities-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
+        if version not in _SCHEMAS.keys():
+            _SCHEMAS[version] = {}
+        _SCHEMAS[version]['iati-activities-schema'] = iati.core.ActivitySchema(activity_schema_paths[0])
+
+    output[version] = _SCHEMAS[version]['iati-activities-schema']
+
+    return output[version]
 
 
-def activity_schemas():
+def activity_schema(version=None):
     """Return a dictionary of the default ActivitySchema objects for all versions of the Standard.
+
+    Args:
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
 
     Returns:
         dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
 
     """
-    return _activity_schemas()
+    return _activity_schema(version)
 
 
-def _organisation_schemas(use_cache=False):
+def _organisation_schema(version=None, use_cache=False):
     """Return a dictionary of the default OrganisationSchema objects for all versions of the Standard.
 
     Args:
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
         use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
 
     Returns:
@@ -185,32 +193,38 @@ def _organisation_schemas(use_cache=False):
 
     """
     output = {}
-    for version in iati.core.constants.STANDARD_VERSIONS:
-        organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
-        if ('iati-organisations-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
-            if version not in _SCHEMAS.keys():
-                _SCHEMAS[version] = {}
-            _SCHEMAS[version]['iati-organisations-schema'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
 
-        output[version] = _SCHEMAS[version]['iati-organisations-schema']
+    version = get_default_version_if_none(version)
 
-    return output
+    organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
+    if ('iati-organisations-schema' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
+        if version not in _SCHEMAS.keys():
+            _SCHEMAS[version] = {}
+        _SCHEMAS[version]['iati-organisations-schema'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
+
+    output[version] = _SCHEMAS[version]['iati-organisations-schema']
+
+    return output[version]
 
 
-def organisation_schemas():
+def organisation_schema(version=None):
     """Return a dictionary of the default OrganisationSchema objects for all versions of the Standard.
+
+    Args:
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
 
     Returns:
         dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
 
     """
-    return _organisation_schemas()
+    return _organisation_schema(version)
 
 
 def _schemas(use_cache=False):
     """Locate all the default IATI Schemas and return them within a dictionary.
 
     Args:
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
         use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
 
     Returns:
@@ -220,41 +234,20 @@ def _schemas(use_cache=False):
         Consider the Schema that defines the format of Codelists.
 
     """
-    _activity_schemas(use_cache)
-    _organisation_schemas(use_cache)
+    _activity_schema(use_cache)
+    _organisation_schema(use_cache)
 
     return _SCHEMAS  # Both activity_schemas and organisation_schemas will update the _SCHEMAS constant.
 
 
-def schemas():
+def schemas(version=None):
     """Locate all the default IATI Schemas and return them within a dictionary.
+
+    Args:
+        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
 
     Returns:
         dict: A dictionary containing all the Schemas for versions of the Standard. This returns the name of the Schema (as the key) and a subclass of iati.core.schemas.Schema() (as the value).
 
     """
-    return _schemas()
-
-
-def schema(name, version=None):
-    """Return a default Schema with the specified name for the specified version of the Standard.
-
-    Args:
-        name (str): The name of the Schema to locate. Current values are 'iati-activities-schema' or 'iati-organisations-schema'.
-        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
-
-    Returns:
-        iati.core.schema.Schema (or subclass): An instance of the schema corresponding to the input name and version.
-
-    Raises:
-        KeyError: If the input schema name is not found as part of the default IATI Schemas.
-
-    """
-    version = get_default_version_if_none(version)
-
-    try:
-        return schemas()[version][name]
-    except KeyError:
-        msg = 'There is no default Schema in version {0} of the Standard with the name {1}.'.format(version, name)
-        iati.core.utilities.log_warning(msg)
-        raise ValueError(msg)
+    return _schemas(version)

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -61,8 +61,6 @@ def codelist(name, version=None):
         Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
 
     Todo:
-        Actually handle versions, including errors.
-
         Better distinguish the types of ValueError.
 
         Better distinguish TypeErrors from KeyErrors - sometimes the latter is raised when the former should have been.
@@ -152,9 +150,6 @@ def activity_schemas(use_cache=False):
     Returns:
         dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
 
-    Todo:
-        Test a cache bypass where data is updated.
-
     """
     output = {}
     for version in iati.core.constants.STANDARD_VERSIONS:
@@ -177,9 +172,6 @@ def organisation_schemas(use_cache=False):
 
     Returns:
         dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
-
-    Todo:
-        Test a cache bypass where data is updated.
 
     """
     output = {}
@@ -206,8 +198,6 @@ def schemas(use_cache=False):
 
     Todo:
         Consider the Schema that defines the format of Codelists.
-
-        Test a cache bypass where data is updated.
 
     """
     activity_schemas(use_cache)

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -215,7 +215,7 @@ def _schema(path_func, schema_class, version=None, populate=True, use_cache=Fals
         ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
-        dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
+        iati.core.Schema: An instantiated IATI Schema for the specified version.
 
     """
     population_key = 'populated' if populate else 'unpopulated'
@@ -244,7 +244,7 @@ def activity_schema(version=None, populate=True):
         ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
-        dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
+        iati.core.ActivitySchema: An instantiated IATI Schema for the specified version.
 
     """
     return _schema(iati.core.resources.get_all_activity_schema_paths, iati.core.ActivitySchema, version, populate)
@@ -261,7 +261,7 @@ def organisation_schema(version=None, populate=True):
         ValueError: When a specified version is not a valid version of the IATI Standard.
 
     Returns:
-        dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
+        iati.core.OrganisationSchema: An instantiated IATI Schema for the specified version.
 
     """
     return _schema(iati.core.resources.get_all_org_schema_paths, iati.core.OrganisationSchema, version, populate)

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -8,8 +8,8 @@ Todo:
     Implement more than Codelists.
 
 """
-from copy import deepcopy
 import os
+from copy import deepcopy
 import iati.core.codelists
 import iati.core.constants
 import iati.core.resources

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -69,7 +69,7 @@ def codelist(name, version=None):
 
     """
     try:
-        codelist_found = codelists(version, True)[name]
+        codelist_found = _codelists(version, True)[name]
         return deepcopy(codelist_found)
     except (KeyError, TypeError):
         msg = "There is no default Codelist in version {0} of the Standard with the name {1}.".format(version, name)
@@ -77,7 +77,7 @@ def codelist(name, version=None):
         raise ValueError(msg)
 
 
-def codelists(version=None, use_cache=False):
+def _codelists(version=None, use_cache=False):
     """Locate the default Codelists for the specified version of the Standard.
 
     Args:
@@ -94,14 +94,8 @@ def codelists(version=None, use_cache=False):
         Setting `use_cache` to `True` is dangerous since it does not return a deep copy of the Codelists. This means that modification of a returned Codelist will modify the Codelist everywhere.
         A `deepcopy()` should be performed on any returned value before it is modified.
 
-        Further exploration needs to be undertaken in how to handle multiple versions of the Standard.
-
-    Todo:
-        Actually handle versions, including errors.
-
-        Test a cache bypass where data is updated.
-
-        Add a function to return a single Codelist by name.
+    Note:
+        This is a private function so as to prevent the (dangerous) `use_cache` parameter being part of the public API.
 
     """
     version = get_default_version_if_none(version)
@@ -119,6 +113,23 @@ def codelists(version=None, use_cache=False):
             _CODELISTS[version] = codelists_by_version
 
     return _CODELISTS[version]
+
+
+def codelists(version=None):
+    """Locate the default Codelists for the specified version of the Standard.
+
+    Args:
+        version (str): The version of the Standard to return the Codelists for. Defaults to None. This means that the latest version of the Codelist is returned.
+
+    Raises:
+        ValueError: When a specified version is not a valid version of the IATI Standard.
+
+    Returns:
+        dict: A dictionary containing all the Codelists at the specified version of the Standard. All Non-Embedded Codelists are included. Keys are Codelist names. Values are iati.core.Codelist() instances.
+
+    """
+    return _codelists(version)
+
 
 
 _SCHEMAS = {}

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -201,7 +201,7 @@ def _populate_schema(schema, version=None):
     return schema
 
 
-def _schema(path_func, schema_class, version=None, populate=False, use_cache=False):
+def _schema(path_func, schema_class, version=None, populate=True, use_cache=False):
     """Return the default Schema of the specified type for the specified version of the Standard.
 
     Args:
@@ -233,7 +233,7 @@ def _schema(path_func, schema_class, version=None, populate=False, use_cache=Fal
     return _SCHEMAS[version][population_key][schema_class.ROOT_ELEMENT_NAME]
 
 
-def activity_schema(version=None, populate=False):
+def activity_schema(version=None, populate=True):
     """Return the default ActivitySchema objects for the specified version of the Standard.
 
     Args:
@@ -250,7 +250,7 @@ def activity_schema(version=None, populate=False):
     return _schema(iati.core.resources.get_all_activity_schema_paths, iati.core.ActivitySchema, version, populate)
 
 
-def organisation_schema(version=None, populate=False):
+def organisation_schema(version=None, populate=True):
     """Return the default OrganisationSchema objects for the specified version of the Standard.
 
     Args:

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -7,6 +7,7 @@ Todo:
     Implement more than Codelists.
 """
 import os
+from collections import defaultdict
 from copy import deepcopy
 import iati.core.codelists
 import iati.core.constants
@@ -33,7 +34,7 @@ def get_default_version_if_none(version):
     return version
 
 
-_CODELISTS = {}
+_CODELISTS = defaultdict(lambda : defaultdict(dict))
 """A cache of loaded Codelists.
 
 This removes the need to repeatedly load a Codelist from disk each time it is accessed.
@@ -146,7 +147,7 @@ def codelists(version=None):
     return _codelists(version)
 
 
-_SCHEMAS = {}
+_SCHEMAS = defaultdict(lambda : defaultdict(dict))
 """A cache of loaded Schemas.
 
 This removes the need to repeatedly load a Schema from disk each time it is accessed.
@@ -193,10 +194,6 @@ def _activity_schema(version=None, use_cache=False):
     activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
 
     if ('activity' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
-        if version not in _SCHEMAS.keys():
-            _SCHEMAS[version] = {}
-        if 'activity' not in _SCHEMAS[version].keys():
-               _SCHEMAS[version]['activity'] = {}
         _SCHEMAS[version]['activity']['unpopulated'] = iati.core.ActivitySchema(activity_schema_paths[0])
 
     return _SCHEMAS[version]['activity']['unpopulated']
@@ -237,10 +234,6 @@ def _organisation_schema(version=None, use_cache=False):
     organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
 
     if ('organisation' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
-        if version not in _SCHEMAS.keys():
-            _SCHEMAS[version] = {}
-        if 'organisation' not in _SCHEMAS[version].keys():
-           _SCHEMAS[version]['organisation'] = {}
         _SCHEMAS[version]['organisation']['unpopulated'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
 
     return _SCHEMAS[version]['organisation']['unpopulated']

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -129,7 +129,6 @@ def codelists(version=None):
     return _codelists(version)
 
 
-
 _SCHEMAS = {}
 """A cache of loaded Schemas.
 

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -153,12 +153,12 @@ This removes the need to repeatedly load a Schema from disk each time it is acce
 {
     "version_number_a": {
         "populated": {
-            "activity": iati.core.ActivitySchema
-            "organisation": iati.core.OrganisationSchema
+            "iati-activities": iati.core.ActivitySchema
+            "iati-organisations": iati.core.OrganisationSchema
         },
         "unpopulated": {
-            "activity": iati.core.ActivitySchema
-            "organisation": iati.core.OrganisationSchema
+            "iati-activities": iati.core.ActivitySchema
+            "iati-organisations": iati.core.OrganisationSchema
         },
     },
     "version_number_b": {
@@ -173,10 +173,12 @@ Warning:
 """
 
 
-def _activity_schema(version=None, use_cache=False):
-    """Return a dictionary of the default ActivitySchema objects for all versions of the Standard.
+def _schema(path_func, schema_class, version=None, use_cache=False):
+    """Return the default Schema of the specified type for the specified version of the Standard.
 
     Args:
+        path_func (func): A function to return the paths at which the relevant Schema can be found.
+        schema_class (type): A class definition for the Schema of interest.
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
         use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
 
@@ -189,16 +191,16 @@ def _activity_schema(version=None, use_cache=False):
     """
     version = get_default_version_if_none(version)
 
-    activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
+    schema_paths = path_func(version)
 
-    if ('activity' not in _SCHEMAS[version].keys()) or not use_cache:
-        _SCHEMAS[version]['activity']['unpopulated'] = iati.core.ActivitySchema(activity_schema_paths[0])
+    if (schema_class.ROOT_ELEMENT_NAME not in _SCHEMAS[version].keys()) or not use_cache:
+        _SCHEMAS[version]['unpopulated'][schema_class.ROOT_ELEMENT_NAME] = schema_class(schema_paths[0])
 
-    return _SCHEMAS[version]['activity']['unpopulated']
+    return _SCHEMAS[version]['unpopulated'][schema_class.ROOT_ELEMENT_NAME]
 
 
 def activity_schema(version=None):
-    """Return a dictionary of the default ActivitySchema objects for all versions of the Standard.
+    """Return the default ActivitySchema objects for the specified version of the Standard.
 
     Args:
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
@@ -210,35 +212,11 @@ def activity_schema(version=None):
         dict: Containing the version (as keys) and a corresponding ActivitySchema object (as values).
 
     """
-    return _activity_schema(version)
-
-
-def _organisation_schema(version=None, use_cache=False):
-    """Return a dictionary of the default OrganisationSchema objects for all versions of the Standard.
-
-    Args:
-        version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
-        use_cache (bool): Whether the cache should be used rather than loading the Schema from disk again. If used, a `deepcopy()` should be performed on any returned Schema before it is modified.
-
-    Raises:
-        ValueError: When a specified version is not a valid version of the IATI Standard.
-
-    Returns:
-        dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
-
-    """
-    version = get_default_version_if_none(version)
-
-    organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
-
-    if ('organisation' not in _SCHEMAS[version].keys()) or not use_cache:
-        _SCHEMAS[version]['organisation']['unpopulated'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
-
-    return _SCHEMAS[version]['organisation']['unpopulated']
+    return _schema(iati.core.resources.get_all_activity_schema_paths, iati.core.ActivitySchema, version)
 
 
 def organisation_schema(version=None):
-    """Return a dictionary of the default OrganisationSchema objects for all versions of the Standard.
+    """Return the default OrganisationSchema objects for the specified version of the Standard.
 
     Args:
         version (str): The version of the Standard to return the Schema for. Defaults to None. This means that the latest version of the Schema is returned.
@@ -250,4 +228,4 @@ def organisation_schema(version=None):
         dict: Containing the version (as keys) and a corresponding OrganisationSchema object (as values).
 
     """
-    return _organisation_schema(version)
+    return _schema(iati.core.resources.get_all_org_schema_paths, iati.core.OrganisationSchema, version)

--- a/iati/core/default.py
+++ b/iati/core/default.py
@@ -34,7 +34,7 @@ def get_default_version_if_none(version):
     return version
 
 
-_CODELISTS = defaultdict(lambda : defaultdict(dict))
+_CODELISTS = defaultdict(dict)
 """A cache of loaded Codelists.
 
 This removes the need to repeatedly load a Codelist from disk each time it is accessed.
@@ -121,12 +121,10 @@ def _codelists(version=None, use_cache=False):
     for path in paths:
         _, filename = os.path.split(path)
         name = filename[:-len(iati.core.resources.FILE_CODELIST_EXTENSION)]  # Get the name of the codelist, without the '.xml' file extension
-        codelists_by_version = _CODELISTS.get(version, {})
-        if (name not in codelists_by_version.keys()) or not use_cache:
+        if (name not in _CODELISTS[version].keys()) or not use_cache:
             xml_str = iati.core.resources.load_as_string(path)
             codelist_found = iati.core.Codelist(name, xml=xml_str)
-            codelists_by_version[name] = codelist_found
-            _CODELISTS[version] = codelists_by_version
+            _CODELISTS[version][name] = codelist_found
 
     return _CODELISTS[version]
 
@@ -193,7 +191,7 @@ def _activity_schema(version=None, use_cache=False):
 
     activity_schema_paths = iati.core.resources.get_all_activity_schema_paths(version)
 
-    if ('activity' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
+    if ('activity' not in _SCHEMAS[version].keys()) or not use_cache:
         _SCHEMAS[version]['activity']['unpopulated'] = iati.core.ActivitySchema(activity_schema_paths[0])
 
     return _SCHEMAS[version]['activity']['unpopulated']
@@ -233,7 +231,7 @@ def _organisation_schema(version=None, use_cache=False):
 
     organisation_schema_paths = iati.core.resources.get_all_org_schema_paths(version)
 
-    if ('organisation' not in _SCHEMAS.get(version, {}).keys()) or not use_cache:
+    if ('organisation' not in _SCHEMAS[version].keys()) or not use_cache:
         _SCHEMAS[version]['organisation']['unpopulated'] = iati.core.OrganisationSchema(organisation_schema_paths[0])
 
     return _SCHEMAS[version]['organisation']['unpopulated']

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -217,4 +217,22 @@ class TestDefaultModifications(object):
         assert len(default_schema.codelists) == base_codelist_count + 1
         assert len(modified_schema.codelists) == base_codelist_count + 1
 
+    @pytest.mark.parametrize("schema_name", [
+        'iati-activities-schema',
+        'iati-organisations-schema'
+    ])
+    def test_default_schema_modification(self, schema_name, standard_version_optional, codelist):
+        """Check that the default Schemas cannot be modified when called individually.
 
+        Note:
+            Implementation is by attempting to add a Codelist to the Schema.
+
+        """
+        default_schema = iati.core.default.schema(schema_name, *standard_version_optional)
+        base_codelist_count = len(default_schema.codelists)
+
+        default_schema.codelists.add(codelist)
+        unmodified_schema = iati.core.default.schema(schema_name, *standard_version_optional)
+
+        assert len(default_schema.codelists) == base_codelist_count + 1
+        assert len(unmodified_schema.codelists) == base_codelist_count

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -168,7 +168,7 @@ class TestDefaultModifications(object):
         iati.core.default.activity_schemas,
         iati.core.default.organisation_schemas
     ])
-    def test_default_x_schema_modification_safe(self, default_call, codelist, standard_version_mandatory):
+    def test_default_x_schema_modification(self, default_call, codelist, standard_version_mandatory):
         """Check that the default Schemas cannot be modified.
 
         Note:
@@ -183,26 +183,6 @@ class TestDefaultModifications(object):
 
         assert len(default_schema.codelists) == base_codelist_count + 1
         assert len(unmodified_schema.codelists) == base_codelist_count
-
-    @pytest.mark.parametrize("default_call", [
-        iati.core.default.activity_schemas,
-        iati.core.default.organisation_schemas
-    ])
-    def test_default_x_schema_modification_dangerous(self, default_call, codelist, standard_version_mandatory):
-        """Check that the default Schemas can be modified when called in DANGER MODE.
-
-        Note:
-            Implementation is by attempting to add a Codelist to the Schema.
-
-        """
-        default_schema = default_call(True)[standard_version_mandatory[0]]
-        base_codelist_count = len(default_schema.codelists)
-
-        default_schema.codelists.add(codelist)
-        modified_schema = default_call(True)[standard_version_mandatory[0]]
-
-        assert len(default_schema.codelists) == base_codelist_count + 1
-        assert len(modified_schema.codelists) == base_codelist_count + 1
 
     @pytest.mark.parametrize("schema_name", [
         'iati-activities-schema',

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -10,10 +10,6 @@ from iati.core.tests.utilities import codelist_lengths_by_version, standard_vers
 class TestDefault(object):
     """A container for tests relating to Default data."""
 
-    @pytest.fixture
-    def codelist_name(self):
-        """Return the name of a valid Codelist."""
-        return 'Country'
 
     @pytest.mark.parametrize("invalid_version", iati.core.tests.utilities.generate_test_types(['none'], True))
     @pytest.mark.parametrize("func_to_check", [
@@ -26,6 +22,16 @@ class TestDefault(object):
         """Check that an invalid version causes an error when obtaining default data."""
         with pytest.raises(ValueError):
             func_to_check(invalid_version)
+
+
+class TestDefaultCodelist(object):
+    """A container for tests relating to default Codelists."""
+
+
+    @pytest.fixture
+    def codelist_name(self):
+        """Return the name of a valid Codelist."""
+        return 'Country'
 
     @pytest.mark.parametrize("invalid_version", iati.core.tests.utilities.generate_test_types(['none'], True))
     def test_invalid_version_single_codelist(self, invalid_version, codelist_name):
@@ -101,6 +107,10 @@ class TestDefault(object):
 
         assert len(codelists) == codelist_lengths_by_version.expected_length
 
+
+class TestDefaultSchemas(object):
+    """A container for tests relating to default Schemas."""
+
     def test_default_activity_schemas(self, standard_version_optional):
         """Check that the default ActivitySchemas are correct.
 
@@ -120,6 +130,26 @@ class TestDefault(object):
         schema = iati.core.default.organisation_schema(*standard_version_optional)
 
         assert isinstance(schema, iati.core.OrganisationSchema)
+
+    @pytest.mark.parametrize("schema_func", [
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
+    ])
+    def test_default_schemas_populated(self, schema_func, codelist_lengths_by_version):
+        """Check that the default Codelists for each version contain the expected number of Codelists."""
+        schema = schema_func(codelist_lengths_by_version.version, True)
+
+        assert len(schema.codelists) == codelist_lengths_by_version.expected_length
+
+    @pytest.mark.parametrize("schema_func", [
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
+    ])
+    def test_default_schemas_unpopulated(self, schema_func, standard_version_mandatory):
+        """Check that the default Codelists for each version contain the expected number of Codelists."""
+        schema = schema_func(*standard_version_mandatory, False)
+
+        assert len(schema.codelists) == 0
 
 
 class TestDefaultModifications(object):

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -131,13 +131,14 @@ class TestDefaultSchemas(object):
 
         assert isinstance(schema, iati.core.OrganisationSchema)
 
+    @pytest.mark.parametrize("population_status", [[], [True]])
     @pytest.mark.parametrize("schema_func", [
         iati.core.default.activity_schema,
         iati.core.default.organisation_schema
     ])
-    def test_default_schemas_populated(self, schema_func, codelist_lengths_by_version):
+    def test_default_schemas_populated(self, population_status, schema_func, codelist_lengths_by_version):
         """Check that the default Codelists for each version contain the expected number of Codelists."""
-        schema = schema_func(codelist_lengths_by_version.version, True)
+        schema = schema_func(codelist_lengths_by_version.version, *population_status)
 
         assert len(schema.codelists) == codelist_lengths_by_version.expected_length
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -10,6 +10,13 @@ from iati.core.tests.utilities import codelist_lengths_by_version, standard_vers
 class TestDefault(object):
     """A container for tests relating to Default data."""
 
+
+    @pytest.mark.parametrize("invalid_version", iati.core.tests.utilities.generate_test_types(['none'], True))
+    def test_get_default_version_if_none_invalid_version_str(self, invalid_version):
+        """Check that an invalid version causes an error."""
+        with pytest.raises(ValueError):
+            iati.core.default.get_default_version_if_none(invalid_version)
+
     def test_default_codelist_valid_at_all_versions(self, standard_version_optional):
         """Check that a named default Codelist may be located.
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -10,7 +10,6 @@ from iati.core.tests.utilities import codelist_lengths_by_version, standard_vers
 class TestDefault(object):
     """A container for tests relating to Default data."""
 
-
     @pytest.fixture
     def codelist_name(self):
         """Return the name of a valid Codelist."""
@@ -64,7 +63,8 @@ class TestDefault(object):
     ])
     def test_default_codelist_valid_only_at_some_versions(self, codelist_name, version, expected_type):
         """Check that a codelist that is valid at some version/s is not valid in other versions.
-        For example:
+
+        Example:
             AidTypeFlag was an embedded codelist in v1.04 and v1.05, but is not valid at any version after this.
             For example, BudgetStatus was added as an embedded codelist in v2.02, so is not valid prior to this.
         """

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -4,7 +4,7 @@ import iati.core.codelists
 import iati.core.constants
 import iati.core.default
 import iati.core.schemas
-from iati.core.tests.utilities import codelist_lengths_by_version, standard_version_optional
+from iati.core.tests.utilities import codelist_lengths_by_version, standard_version_mandatory, standard_version_optional
 
 
 class TestDefault(object):
@@ -136,7 +136,7 @@ class TestDefaultModifications(object):
         return iati.core.Code('new code value', 'new code name')
 
     def test_default_codelist_modification(self, codelist_name, new_code, standard_version_optional):
-        """Check that default Codelists cannot be modified by adding Codes to returned lists."""
+        """Check that a default Codelist cannot be modified by adding Codes to returned lists."""
         default_codelist = iati.core.default.codelist(codelist_name, *standard_version_optional)
         base_default_codelist_length = len(default_codelist.codes)
 
@@ -145,3 +145,29 @@ class TestDefaultModifications(object):
 
         assert len(default_codelist.codes) == base_default_codelist_length + 1
         assert len(unmodified_codelist.codes) == base_default_codelist_length
+
+    def test_default_codelists_modification_safe(self, codelist_name, new_code, standard_version_optional):
+        """Check that default Codelists cannot be modified by adding Codes to returned lists with default parameters."""
+        default_codelists = iati.core.default.codelists(*standard_version_optional)
+        codelist_of_interest = default_codelists[codelist_name]
+        base_default_codelist_length = len(codelist_of_interest.codes)
+
+        codelist_of_interest.codes.add(new_code)
+        unmodified_codelists = iati.core.default.codelists(*standard_version_optional)
+        unmodified_codelist_of_interest = unmodified_codelists[codelist_name]
+
+        assert len(codelist_of_interest.codes) == base_default_codelist_length + 1
+        assert len(unmodified_codelist_of_interest.codes) == base_default_codelist_length
+
+    def test_default_codelists_modification_dangerous(self, codelist_name, new_code, standard_version_mandatory):
+        """Check that default Codelists cannot be modified by adding Codes to returned lists."""
+        default_codelists = iati.core.default.codelists(*standard_version_mandatory, True)
+        codelist_of_interest = default_codelists[codelist_name]
+        base_default_codelist_length = len(codelist_of_interest.codes)
+
+        codelist_of_interest.codes.add(new_code)
+        unmodified_codelists = iati.core.default.codelists(*standard_version_mandatory, True)
+        unmodified_codelist_of_interest = unmodified_codelists[codelist_name]
+
+        assert len(codelist_of_interest.codes) == base_default_codelist_length + 1
+        assert len(unmodified_codelist_of_interest.codes) == base_default_codelist_length + 1

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -172,7 +172,7 @@ class TestDefaultModifications(object):
 
         codelist_of_interest.codes.add(new_code)
         modified_codelists = iati.core.default.codelists(standard_version_mandatory[0], True)
-        modified_codelist_of_interest = unmodified_codelists[codelist_name]
+        modified_codelist_of_interest = modified_codelists[codelist_name]
 
         assert len(codelist_of_interest.codes) == base_default_codelist_length + 1
         assert len(modified_codelist_of_interest.codes) == base_default_codelist_length + 1

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -119,3 +119,29 @@ class TestDefault(object):
         """Check that an Error is raised when attempting to load a Schema name that does not exist."""
         with pytest.raises((ValueError, TypeError)):
             iati.core.default.schema(invalid_name)
+
+
+class TestDefaultModifications(object):
+    """A container for tests relating to the ability to modify defaults."""
+
+
+    @pytest.fixture
+    def codelist_name(self):
+        """Return the name of a Codelist that exists at all versions of the Standard."""
+        return 'Country'
+
+    @pytest.fixture
+    def new_code(self):
+        """Return a Code object that has not been added to a Codelist."""
+        return iati.core.Code('new code value', 'new code name')
+
+    def test_default_codelist_modification(self, codelist_name, new_code, standard_version_optional):
+        """Check that default Codelists cannot be modified by adding Codes to returned lists."""
+        default_codelist = iati.core.default.codelist(codelist_name, *standard_version_optional)
+        base_default_codelist_length = len(default_codelist.codes)
+
+        default_codelist.codes.add(new_code)
+        unmodified_codelist = iati.core.default.codelist(codelist_name, *standard_version_optional)
+
+        assert len(default_codelist.codes) == base_default_codelist_length + 1
+        assert len(unmodified_codelist.codes) == base_default_codelist_length

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -166,12 +166,12 @@ class TestDefaultModifications(object):
 
     def test_default_codelists_modification_dangerous(self, codelist_name, new_code, standard_version_mandatory):
         """Check that default Codelists can be modified by adding Codes to returned lists in DANGER MODE."""
-        default_codelists = iati.core.default.codelists(*standard_version_mandatory, True)
+        default_codelists = iati.core.default.codelists(standard_version_mandatory[0], True)
         codelist_of_interest = default_codelists[codelist_name]
         base_default_codelist_length = len(codelist_of_interest.codes)
 
         codelist_of_interest.codes.add(new_code)
-        modified_codelists = iati.core.default.codelists(*standard_version_mandatory, True)
+        modified_codelists = iati.core.default.codelists(standard_version_mandatory[0], True)
         modified_codelist_of_interest = unmodified_codelists[codelist_name]
 
         assert len(codelist_of_interest.codes) == base_default_codelist_length + 1

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -93,21 +93,6 @@ class TestDefault(object):
 
         assert isinstance(schema, iati.core.OrganisationSchema)
 
-    def test_default_schemas(self):
-        """Check that the default Schemas are correct.
-
-        Todo:
-            Check internal values beyond the schemas being the correct type.
-        """
-        version = iati.core.constants.STANDARD_VERSION_LATEST
-        schemas = iati.core.default.schemas()
-
-        assert isinstance(schemas, dict)
-        assert isinstance(schemas[version], dict)
-        assert len(schemas[version]) == 2
-        for schema in schemas[version].values():
-            assert isinstance(schema, (iati.core.ActivitySchema, iati.core.OrganisationSchema))
-
 
 class TestDefaultModifications(object):
     """A container for tests relating to the ability to modify defaults."""

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -148,7 +148,7 @@ class TestDefaultSchemas(object):
     ])
     def test_default_schemas_unpopulated(self, schema_func, standard_version_mandatory):
         """Check that the default Codelists for each version contain the expected number of Codelists."""
-        schema = schema_func(*standard_version_mandatory, False)
+        schema = schema_func(standard_version_mandatory[0], False)
 
         assert len(schema.codelists) == 0
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -181,7 +181,7 @@ class TestDefaultModifications(object):
         iati.core.default.activity_schemas,
         iati.core.default.organisation_schemas
     ])
-    def test_default_activity_schema_modification_safe(self, default_call, codelist, standard_version_mandatory):
+    def test_default_x_schema_modification_safe(self, default_call, codelist, standard_version_mandatory):
         """Check that the default Schemas cannot be modified.
 
         Note:
@@ -201,7 +201,7 @@ class TestDefaultModifications(object):
         iati.core.default.activity_schemas,
         iati.core.default.organisation_schemas
     ])
-    def test_default_activity_schema_modification_dangerous(self, default_call, codelist, standard_version_mandatory):
+    def test_default_x_schema_modification_dangerous(self, default_call, codelist, standard_version_mandatory):
         """Check that the default Schemas can be modified when called in DANGER MODE.
 
         Note:
@@ -216,4 +216,5 @@ class TestDefaultModifications(object):
 
         assert len(default_schema.codelists) == base_codelist_count + 1
         assert len(modified_schema.codelists) == base_codelist_count + 1
+
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -151,7 +151,7 @@ class TestDefaultModifications(object):
         assert len(default_codelist.codes) == base_default_codelist_length + 1
         assert len(unmodified_codelist.codes) == base_default_codelist_length
 
-    def test_default_codelists_modification_safe(self, codelist_name, new_code, standard_version_optional):
+    def test_default_codelists_modification(self, codelist_name, new_code, standard_version_optional):
         """Check that default Codelists cannot be modified by adding Codes to returned lists with default parameters."""
         default_codelists = iati.core.default.codelists(*standard_version_optional)
         codelist_of_interest = default_codelists[codelist_name]
@@ -163,19 +163,6 @@ class TestDefaultModifications(object):
 
         assert len(codelist_of_interest.codes) == base_default_codelist_length + 1
         assert len(unmodified_codelist_of_interest.codes) == base_default_codelist_length
-
-    def test_default_codelists_modification_dangerous(self, codelist_name, new_code, standard_version_mandatory):
-        """Check that default Codelists can be modified by adding Codes to returned lists in DANGER MODE."""
-        default_codelists = iati.core.default.codelists(standard_version_mandatory[0], True)
-        codelist_of_interest = default_codelists[codelist_name]
-        base_default_codelist_length = len(codelist_of_interest.codes)
-
-        codelist_of_interest.codes.add(new_code)
-        modified_codelists = iati.core.default.codelists(standard_version_mandatory[0], True)
-        modified_codelist_of_interest = modified_codelists[codelist_name]
-
-        assert len(codelist_of_interest.codes) == base_default_codelist_length + 1
-        assert len(modified_codelist_of_interest.codes) == base_default_codelist_length + 1
 
     @pytest.mark.parametrize("default_call", [
         iati.core.default.activity_schemas,

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -11,23 +11,44 @@ class TestDefault(object):
     """A container for tests relating to Default data."""
 
 
-    @pytest.mark.parametrize("invalid_version", iati.core.tests.utilities.generate_test_types(['none'], True))
-    def test_get_default_version_if_none_invalid_version_str(self, invalid_version):
-        """Check that an invalid version causes an error."""
-        with pytest.raises(ValueError):
-            iati.core.default.get_default_version_if_none(invalid_version)
+    @pytest.fixture
+    def codelist_name(self):
+        """Return the name of a valid Codelist."""
+        return 'Country'
 
-    def test_default_codelist_valid_at_all_versions(self, standard_version_optional):
+    @pytest.mark.parametrize("invalid_version", iati.core.tests.utilities.generate_test_types(['none'], True))
+    @pytest.mark.parametrize("func_to_check", [
+        iati.core.default.get_default_version_if_none,
+        iati.core.default.codelists,
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
+    ])
+    def test_invalid_version(self, invalid_version, func_to_check):
+        """Check that an invalid version causes an error when obtaining default data."""
+        with pytest.raises(ValueError):
+            func_to_check(invalid_version)
+
+    @pytest.mark.parametrize("invalid_version", iati.core.tests.utilities.generate_test_types(['none'], True))
+    def test_invalid_version_single_codelist(self, invalid_version, codelist_name):
+        """Check that an invalid version causes an error when obtaining a single default Codelist.
+
+        Note:
+            This is a separate test since the function takes a parameter other than the `version`.
+
+        """
+        with pytest.raises(ValueError):
+            iati.core.default.codelist(codelist_name, invalid_version)
+
+    def test_default_codelist_valid_at_all_versions(self, codelist_name, standard_version_optional):
         """Check that a named default Codelist may be located.
 
         Todo:
             Check internal values beyond the codelists being the correct type.
         """
-        name = 'Country'
-        codelist = iati.core.default.codelist(name, *standard_version_optional)
+        codelist = iati.core.default.codelist(codelist_name, *standard_version_optional)
 
         assert isinstance(codelist, iati.core.Codelist)
-        assert codelist.name == name
+        assert codelist.name == codelist_name
         for code in codelist.codes:
             assert isinstance(code, iati.core.Code)
 

--- a/iati/core/tests/test_default.py
+++ b/iati/core/tests/test_default.py
@@ -73,31 +73,25 @@ class TestDefault(object):
 
         assert len(codelists) == codelist_lengths_by_version.expected_length
 
-    def test_default_activity_schemas(self):
+    def test_default_activity_schemas(self, standard_version_optional):
         """Check that the default ActivitySchemas are correct.
 
         Todo:
             Check internal values beyond the schemas being the correct type.
         """
-        schemas = iati.core.default.activity_schemas()
+        schema = iati.core.default.activity_schema(*standard_version_optional)
 
-        assert isinstance(schemas, dict)
-        assert len(schemas) == len(iati.core.constants.STANDARD_VERSIONS)
-        for _, schema in schemas.items():
-            assert isinstance(schema, iati.core.ActivitySchema)
+        assert isinstance(schema, iati.core.ActivitySchema)
 
-    def test_default_organisation_schemas(self):
+    def test_default_organisation_schemas(self, standard_version_optional):
         """Check that the default ActivitySchemas are correct.
 
         Todo:
             Check internal values beyond the schemas being the correct type.
         """
-        schemas = iati.core.default.organisation_schemas()
+        schema = iati.core.default.organisation_schema(*standard_version_optional)
 
-        assert isinstance(schemas, dict)
-        assert len(schemas) == len(iati.core.constants.STANDARD_VERSIONS)
-        for _, schema in schemas.items():
-            assert isinstance(schema, iati.core.OrganisationSchema)
+        assert isinstance(schema, iati.core.OrganisationSchema)
 
     def test_default_schemas(self):
         """Check that the default Schemas are correct.
@@ -113,12 +107,6 @@ class TestDefault(object):
         assert len(schemas[version]) == 2
         for schema in schemas[version].values():
             assert isinstance(schema, (iati.core.ActivitySchema, iati.core.OrganisationSchema))
-
-    @pytest.mark.parametrize("invalid_name", iati.core.tests.utilities.generate_test_types([], True))
-    def test_default_schema(self, invalid_name):
-        """Check that an Error is raised when attempting to load a Schema name that does not exist."""
-        with pytest.raises((ValueError, TypeError)):
-            iati.core.default.schema(invalid_name)
 
 
 class TestDefaultModifications(object):
@@ -165,8 +153,8 @@ class TestDefaultModifications(object):
         assert len(unmodified_codelist_of_interest.codes) == base_default_codelist_length
 
     @pytest.mark.parametrize("default_call", [
-        iati.core.default.activity_schemas,
-        iati.core.default.organisation_schemas
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
     ])
     def test_default_x_schema_modification(self, default_call, codelist, standard_version_mandatory):
         """Check that the default Schemas cannot be modified.
@@ -175,31 +163,31 @@ class TestDefaultModifications(object):
             Implementation is by attempting to add a Codelist to the Schema.
 
         """
-        default_schema = default_call()[standard_version_mandatory[0]]
+        default_schema = default_call(standard_version_mandatory[0])
         base_codelist_count = len(default_schema.codelists)
 
         default_schema.codelists.add(codelist)
-        unmodified_schema = default_call()[standard_version_mandatory[0]]
+        unmodified_schema = default_call(standard_version_mandatory[0])
 
         assert len(default_schema.codelists) == base_codelist_count + 1
         assert len(unmodified_schema.codelists) == base_codelist_count
 
-    @pytest.mark.parametrize("schema_name", [
-        'iati-activities-schema',
-        'iati-organisations-schema'
+    @pytest.mark.parametrize("schema_func", [
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
     ])
-    def test_default_schema_modification(self, schema_name, standard_version_optional, codelist):
+    def test_default_schema_modification(self, schema_func, standard_version_optional, codelist):
         """Check that the default Schemas cannot be modified when called individually.
 
         Note:
             Implementation is by attempting to add a Codelist to the Schema.
 
         """
-        default_schema = iati.core.default.schema(schema_name, *standard_version_optional)
+        default_schema = schema_func(*standard_version_optional)
         base_codelist_count = len(default_schema.codelists)
 
         default_schema.codelists.add(codelist)
-        unmodified_schema = iati.core.default.schema(schema_name, *standard_version_optional)
+        unmodified_schema = schema_func(*standard_version_optional)
 
         assert len(default_schema.codelists) == base_codelist_count + 1
         assert len(unmodified_schema.codelists) == base_codelist_count

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -1,5 +1,4 @@
 """A module containing tests for the library representation of Schemas."""
-from collections import namedtuple
 from lxml import etree
 import pytest
 import iati.core.codelists

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -29,7 +29,7 @@ class TestSchemas(object):
         For use where both ActivitySchema and OrganisaionSchema must produce the same result.
 
         Returns:
-            iati.core.ActivitySchema / iati.core.OrganisationSchema: An activity and organisaion that has been initialised based on the default IATI Activity and Organisaion schemas.
+            iati.core.Schema: An activity or organisaion Schema that has been initialised.
 
         """
         schema_path = request.param['path_func'](*standard_version_optional)[0]

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -13,8 +13,8 @@ class TestSchemas(object):
     """A container for tests relating to Schemas."""
 
     @pytest.fixture(params=[
-        iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID,
-        iati.core.tests.utilities.SCHEMA_ORGANISATION_NAME_VALID
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
     ])
     def schema_initialised(self, request, standard_version_optional):
         """Create and return a single ActivitySchema or OrganisaionSchema object.
@@ -24,17 +24,17 @@ class TestSchemas(object):
             iati.core.ActivitySchema / iati.core.OrganisationSchema: An activity and organisaion that has been initialised based on the default IATI Activity and Organisaion schemas.
 
         """
-        schema_name = request.param
+        schema_func = request.param
 
-        return iati.core.default.schema(schema_name, *standard_version_optional)
+        return schema_func(*standard_version_optional)
 
-    @pytest.mark.parametrize("schema_type, expected_root_element_name", [
-        ('iati-activities-schema', 'iati-activities'),
-        ('iati-organisations-schema', 'iati-organisations')
+    @pytest.mark.parametrize("schema_func, expected_root_element_name", [
+        (iati.core.default.activity_schema, 'iati-activities'),
+        (iati.core.default.organisation_schema, 'iati-organisations')
     ])
-    def test_schema_default_attributes(self, standard_version_optional, schema_type, expected_root_element_name):
+    def test_schema_default_attributes(self, standard_version_optional, schema_func, expected_root_element_name):
         """Check a Schema's default attributes are correct."""
-        schema = iati.core.default.schema(schema_type, *standard_version_optional)
+        schema = schema_func(*standard_version_optional)
 
         assert schema.ROOT_ELEMENT_NAME == expected_root_element_name
         assert expected_root_element_name in schema._source_path
@@ -46,14 +46,14 @@ class TestSchemas(object):
         assert isinstance(schema_initialised.rulesets, set)
         assert not schema_initialised.rulesets
 
-    @pytest.mark.parametrize("schema_name", [
-        iati.core.tests.utilities.SCHEMA_ACTIVITY_NAME_VALID,
-        iati.core.tests.utilities.SCHEMA_ORGANISATION_NAME_VALID
+    @pytest.mark.parametrize("schema_func", [
+        iati.core.default.activity_schema,
+        iati.core.default.organisation_schema
     ])
-    @pytest.mark.parametrize('version', iati.core.constants.STANDARD_VERSIONS)
-    def test_schema_get_version(self, schema_name, version):
+    @pytest.mark.parametrize('version', ['1.04']) # iati.core.constants.STANDARD_VERSIONS)
+    def test_schema_get_version(self, schema_func, version):
         """Check that the correct version number is returned by the base classes of iati.core.schemas.schema._get_version()."""
-        schema = iati.core.default.schema(schema_name, version)
+        schema = schema_func(version)
         result = schema._get_version()
 
         assert result == version

--- a/iati/core/tests/test_schemas.py
+++ b/iati/core/tests/test_schemas.py
@@ -1,9 +1,11 @@
 """A module containing tests for the library representation of Schemas."""
+from collections import namedtuple
 from lxml import etree
 import pytest
 import iati.core.codelists
 import iati.core.default
 import iati.core.exceptions
+import iati.core.resources
 import iati.core.schemas
 import iati.core.tests.utilities
 from iati.core.tests.utilities import standard_version_optional
@@ -13,8 +15,14 @@ class TestSchemas(object):
     """A container for tests relating to Schemas."""
 
     @pytest.fixture(params=[
-        iati.core.default.activity_schema,
-        iati.core.default.organisation_schema
+        {
+            "path_func": iati.core.resources.get_all_activity_schema_paths,
+            "schema_class": iati.core.ActivitySchema
+        },
+        {
+            "path_func": iati.core.resources.get_all_org_schema_paths,
+            "schema_class": iati.core.OrganisationSchema
+        }
     ])
     def schema_initialised(self, request, standard_version_optional):
         """Create and return a single ActivitySchema or OrganisaionSchema object.
@@ -24,9 +32,8 @@ class TestSchemas(object):
             iati.core.ActivitySchema / iati.core.OrganisationSchema: An activity and organisaion that has been initialised based on the default IATI Activity and Organisaion schemas.
 
         """
-        schema_func = request.param
-
-        return schema_func(*standard_version_optional)
+        schema_path = request.param['path_func'](*standard_version_optional)[0]
+        return request.param['schema_class'](schema_path)
 
     @pytest.mark.parametrize("schema_func, expected_root_element_name", [
         (iati.core.default.activity_schema, 'iati-activities'),

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -157,6 +157,3 @@ def standard_version_optional(request):
         return []
     else:
         return [request.param]
-
-
-

--- a/iati/core/tests/utilities.py
+++ b/iati/core/tests/utilities.py
@@ -128,9 +128,24 @@ def generate_test_types(types, invert_types=False):
     return results
 
 
+@pytest.fixture(params=iati.core.constants.STANDARD_VERSIONS)
+def standard_version_mandatory(request):
+    """Return a list that can be passed to a function using the argument list unpacking functionality - see https://docs.python.org/3.6/tutorial/controlflow.html#unpacking-argument-lists
+
+    For example, the returned list can be used to test functions (such as `iati.core.default.codelists`) which has an optional parameter for the version, or can expect version=None. It has an optional parameter after the version.
+    In this case test usage would be `iati.core.default.codelists(*standard_version_mandatory)`.
+
+    Returns:
+        list: A string which corresponds to a version of the Standard.
+
+    """
+    return [request.param]
+
+
 @pytest.fixture(params=['no_arguments', None] + iati.core.constants.STANDARD_VERSIONS)
 def standard_version_optional(request):
     """Return a list that can be passed to a function using the argument list unpacking functionality - see https://docs.python.org/3.6/tutorial/controlflow.html#unpacking-argument-lists
+
     For example, the returned list can be used to test functions (such as `get_all_codelist_paths`) which has an optional parameter for the version, or can expect version=None.,
     In this case test usage would be `get_all_codelist_paths(*standard_version_optional)`.
 
@@ -142,3 +157,6 @@ def standard_version_optional(request):
         return []
     else:
         return [request.param]
+
+
+


### PR DESCRIPTION
The `iati.core.default` module has functions that return a number of useful default objects. If implemented badly, modification of these values from a calling function will modify the defaults themselves. This would be bad.

This PR adds tests to ensure it is challenging or impossible to accidentally modify defaults. It also improves the implementation by making the interfaces more consistent and less dangerous.

Fixes #148 
Fixes #146 