### PR TITLE
Add strict linting when merging to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,26 @@ stages:
 jobs:
     include:
         - stage: lax lint and other checks
-          python: 3.6
+          python: 3.5
           script:
             - make lint
             - make complexity
             - make docs
           if: branch=dev
         - stage: strict lint
-          python: 3.6
+          python: 3.5
           install: pip install pylint
           env: LINTER=pylint
           script: make pylint
           if: branch=master
         - stage: strict lint
-          python: 3.6
+          python: 3.5
           install: pip install flake8
           env: LINTER=flake8
           script: make flake8
           if: branch=master
         - stage: strict lint
-          python: 3.6
+          python: 3.5
           install: pip install pydocstyle
           env: LINTER=pydocstyle
           script: make pydocstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,40 @@ language: python
 cache:
     pip
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 install:
-    - pip install -U pip wheel
-    - pip install -r requirements-dev.txt
+  - pip install -U pip wheel
+  - pip install -r requirements-dev.txt
 script:
-    - make test
-    - make lint
-    - make complexity
-    - make docs
+  - make test
+  - make lint
+  - make complexity
+  - make docs
+
+stages:
+  - test
+  - strict lint
+
+jobs:
+    include:
+        - stage: strict lint
+          python: 3.6
+          install: pip install pylint
+          env: LINTER=pylint
+          script: make pylint
+          if: branch=master
+        - stage: strict lint
+          python: 3.6
+          install: pip install flake8
+          env: LINTER=flake8
+          script: make flake8
+          if: branch=master
+        - stage: strict lint
+          python: 3.6
+          install: pip install pydocstyle
+          env: LINTER=pydocstyle
+          script: make pydocstyle
+          if: branch=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,21 @@ install:
   - pip install -r requirements-dev.txt
 script:
   - make test
-  - make lint
-  - make complexity
-  - make docs
 
 stages:
   - test
+  - lax lint
   - strict lint
 
 jobs:
     include:
+        - stage: lax lint and other checks
+          python: 3.6
+          script:
+            - make lint
+            - make complexity
+            - make docs
+          if: branch=dev
         - stage: strict lint
           python: 3.6
           install: pip install pylint

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,23 @@ docs: $(IATI_FOLDER) $(DOCS_FOLDER_SOURCE)
 
 
 lint: $(IATI_FOLDER)
-	-pylint $(IATI_FOLDER)
+	-make pylint
 	echo $(LINE_SEP)
-	-flake8 $(IATI_FOLDER)
+	-make flake8
 	echo $(LINE_SEP)
-	- pydocstyle $(IATI_FOLDER)
+	-make pydocstyle
+
+
+pylint: $(IATI_FOLDER)
+	pylint $(IATI_FOLDER)
+
+
+flake8: $(IATI_FOLDER)
+	flake8 $(IATI_FOLDER)
+
+
+pydocstyle: $(IATI_FOLDER)
+	pydocstyle $(IATI_FOLDER)
 
 
 test: $(IATI_FOLDER)


### PR DESCRIPTION
master should only have well-linting code in it. Note that this is probably a tad strict at present due to some linter errors we don't care about not being ignored.

This uses Travis features released today https://github.com/travis-ci/beta-features/issues/28 - other conditions and build stages could be added if desired (it's a pretty cool feature, though the syntax isn't entirely obvious).