### PR TITLE
Add missing license info

### DIFF
--- a/LICENSES-3RD-PARTY.txt
+++ b/LICENSES-3RD-PARTY.txt
@@ -413,10 +413,13 @@ Public License instead of this License.
     applies to:
     - flake8, Copyright (C) 2011-2013 Tarek Ziade <tarek@ziade.org>
               Copyright (C) 2012-2016 Ian Cordasco <graffatcolmingov@gmail.com>
+    - future, Copyright (c) 2013-2016 Python Charmers Pty Ltd, Australia
+    - jsonschema, Copyright (c) 2013 Julian Berman
     - pydocstyle, Copyright (c) 2012 GreenSteam, <http://greensteam.dk/>
                   Copyright (c) 2014-2017 Amir Rachum, <http://amir.rachum.com/>
     - pytest, Copyright (c) 2004-2016 Holger Krekel and others
     - pytest-cov, Copyright (c) 2010 Meme Dough
+    - pytest-xdist
     - radon, Copyright (c) 2012-2014 Michele Lacchia
     - six, Copyright (c) 2010-2015 Benjamin Peterson
     - sphinx_rtd_theme, Copyright (c) 2013 Dave Snider


### PR DESCRIPTION
Several 3rd party tools were being used, though were not listed in the relevant document. This adds them.

`pytest-xdist` has no copyright info listed, so there is nothing listed here.