### PR TITLE
Remove duplicate dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,6 @@ pytest-xdist==1.20.0 # rq.filter: <2.0
 
 # python2/python3 compatibility library
 future==0.16.0 # rq.filter: <1.0
-six==1.10.0 # rq.filter: <2.0
 
 #
 # distribution requirements


### PR DESCRIPTION
'six' was specified in both `requirements_dev.txt` and `setup.py`.

This removes it from the .txt file since it's already defined somewhere that is imported when that is run.