### PR TITLE
Change RuleDateOrder to permit equal `less` and `more` values

### DIFF
--- a/iati/core/resources/test_data/202/invalid_dateorder.xml
+++ b/iati/core/resources/test_data/202/invalid_dateorder.xml
@@ -4,15 +4,12 @@
   <condition></condition><!--condition case-->
   <element1>2017-08-16</element1><!--elements in wrong chronological order-->
   <element2>2016-08-16</element2>
-  <element3>2017-08-16</element3><!--elements have identical values-->
-  <element4>2017-08-16</element4>
   <element5>2016-08-16</element5><!--`more` as chronologically before NOW-->
   <element6>9999-12-01</element6><!--`less` as chronologically after NOW-->
   <nest>
     <element7>2017-08-16</element7><!--elements in wrong chronological order when elements are nested-->
     <element8>2016-08-16</element8>
   </nest>
-  <element9>2017-08-16</element9><!--element is used by `less` and `more`-->
   <element10>2017-08-16</element10><!--multiple `less` elements that are identical but chronologically after `more`-->
   <element10>2017-08-16</element10>
   <element11>2016-08-16</element11>
@@ -21,15 +18,12 @@
   <element13>2016-08-16</element13>
   <element14 attribute="2017-08-16"></element14><!--attributes in wrong chronological order-->
   <element15 attribute="2016-08-16"></element15>
-  <element16 attribute="2017-08-16"></element16><!--attributes have identical values-->
-  <element17 attribute="2017-08-16"></element17>
   <element18 attribute="2016-08-16"></element18><!--attribute in wrong chronological order when `less` is NOW-->
   <element19 attribute="9999-12-01"></element19><!--attribute in wrong chronological order when `more` is NOW-->
   <nest>
     <element20 attribute="2017-08-16"></element20><!--attributes in wrong chronological order when attributes are nested-->
     <element21 attribute="2016-08-16"></element21>
   </nest>
-  <element22 attribute="2017-08-16"></element22><!--element is used by `less and `more-->
   <element23 attribute="2017-08-16"></element23><!--multiple 'less' attributes that are chronologically after 'more'-->
   <element23 attribute="2017-08-16"></element23>
   <element24 attribute="2016-08-16"></element24>

--- a/iati/core/resources/test_data/202/valid_dateorder.xml
+++ b/iati/core/resources/test_data/202/valid_dateorder.xml
@@ -62,4 +62,10 @@
   <element44 attribute="2017-08-25"></element44>
   <element45 attribute="2016-08-25"></element45><!--more date missing-->
   <element46 attribute=""></element46>
+  <element47>2017-08-16</element47><!--elements have identical values-->
+  <element48>2017-08-16</element48>
+  <element49 attribute="2017-08-16"></element49><!--attributes have identical values-->
+  <element50 attribute="2017-08-16"></element50>
+  <element51>2017-08-16</element51><!--element is used by `less` and `more`-->
+  <element52 attribute="2017-08-16"></element52>
 </root_element>

--- a/iati/core/rulesets.py
+++ b/iati/core/rulesets.py
@@ -577,7 +577,7 @@ class RuleDateOrder(Rule):
             if early_date is None or later_date is None:
                 return None
 
-            if early_date >= later_date:
+            if early_date > later_date:
                 return False
         except TypeError:
             # a TypeError is raised in python3 if either of the dates is None

--- a/iati/core/tests/test_rulesets.py
+++ b/iati/core/tests/test_rulesets.py
@@ -564,7 +564,11 @@ class TestRuleDateOrder(RuleSubclassTestBase):
         {'less': 'element35/@attribute', 'more': 'element36/@attribute'},
         {'less': 'nOw', 'more': 'noW'},  # not special case, should treat as regular path value
         {'less': 'now/@attribute', 'more': 'Now/@attribute'},
-        {'less': 'element37', 'more': 'element38'}  # multiple identical elements
+        {'less': 'element37', 'more': 'element38'},  # multiple identical elements
+        {'less': 'element47', 'more': 'element48'},  # dates have identical values
+        {'less': 'element49/@attribute', 'more': 'element50/@attribute'},
+        {'less': 'element51', 'more': 'element51'},  # `less` and `more` reference the same date
+        {'less': 'element52/@attribute', 'more': 'element52/@attribute'}
     ]
 
     all_valid_cases = instatiating_cases + validating_cases
@@ -583,16 +587,12 @@ class TestRuleDateOrder(RuleSubclassTestBase):
     invalidating_cases = [
         {'less': 'element1', 'more': 'element2'},  # dates not in chronological order
         {'less': 'element14/@attribute', 'more': 'element15/@attribute'},
-        {'less': 'element3', 'more': 'element4'},  # dates have identical values
-        {'less': 'element16/@attribute', 'more': 'element17/@attribute'},
         {'less': 'NOW', 'more': 'element5'},  # `more` is chronologically before NOW
         {'less': 'NOW', 'more': 'element18/@attribute'},
         {'less': 'element6', 'more': 'NOW'},  # `less` is chronologically after NOW
         {'less': 'element19/@attribute', 'more': 'NOW'},
         {'less': '//element7', 'more': '//element8'},  # nested dates not in chronological order
         {'less': '//element20/@attribute', 'more': '//element21/@attribute'},
-        {'less': 'element9', 'more': 'element9'},  # `less` and `more` reference the same date
-        {'less': 'element22/@attribute', 'more': 'element22/@attribute'},
         {'less': 'element10', 'more': 'element11'},  # multiple identical `less` dates that are chronologically after `more`
         {'less': 'element23/@attribute', 'more': 'element24/@attribute'},
         {'less': 'element12', 'more': 'element13'},  # multiple identical `more` dates that are chronologically before `less`


### PR DESCRIPTION
This is in response to the change in the issue:
  IATI/IATI-Rulesets#41

The PRs relating to changing the Rule itself (in the Rulesets repo) should be merged before this.