### PR TITLE
Check code and codelist inequality

### DIFF
--- a/iati/core/codelists.py
+++ b/iati/core/codelists.py
@@ -101,6 +101,15 @@ class Codelist(object):
         """
         return ((self.name) == (other.name)) and (collections.Counter(self.codes) == collections.Counter(other.codes))
 
+    def __ne__(self, other):
+        """Check Codelist inequality.
+
+        Note:
+            This is required since there are no implicit relationships when comparing objects. https://docs.python.org/2/reference/datamodel.html#object.__ne__
+
+        """
+        return not self == other
+
     def __hash__(self):
         """Hash the Codelist.
 
@@ -202,6 +211,15 @@ class Code(object):
 
         """
         return ((self.name) == (other.name)) and ((self.value) == (other.value))
+
+    def __ne__(self, other):
+        """Check Code inequality.
+
+        Note:
+            This is required since there are no implicit relationships when comparing objects. https://docs.python.org/2/reference/datamodel.html#object.__ne__
+
+        """
+        return not self == other
 
     def __hash__(self):
         """Hash the Code.


### PR DESCRIPTION
This is required since there are no implicit relationships when comparing objects.

https://docs.python.org/2/reference/datamodel.html#object.__ne__

This was identified by https://lgtm.com/projects/g/IATI/iati.core/alerts/?mode=list

https://stackoverflow.com/questions/4352244/python-should-i-implement-ne-operator-based-on-eq has more info