### PR TITLE
Update dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@
 # linters
 flake8==3.4.1 # rq.filter: <4.0
 pydocstyle==2.0.0 # rq.filter: <3.0
-pylint==1.7.2 # rq.filter: <2.0
+pylint==1.7.4 # rq.filter: <2.0
 
 # code complexity
 radon==2.1.1 # rq.filter: <3.0
@@ -28,5 +28,5 @@ future==0.16.0 # rq.filter: <1.0
 #
 
 # documentation
-Sphinx==1.6.3 # rq.filter: <2.0
+Sphinx==1.6.4 # rq.filter: <2.0
 sphinx-rtd-theme==0.2.4 # rq.filter: <1.0

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
         # JSON schema parsing validation
         'jsonschema==2.6.0',
         # XML handling library
-        'lxml==3.8.0',
+        'lxml==4.0.0',
         # python2/python3 compatibility library
-        'six==1.10.0'
+        'six==1.11.0'
         ],
     classifiers = [
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
requires.io doesn't seem to be doing this, so manual it shall be

The one notable change is the jump from lxml v3 to v4. All the tests appear to pass, and I'm unclear from the lxml changelog what's happened that is not backwards-compatible. As such, this seems like a reasonable change so that we can gain the benefits of future updates.